### PR TITLE
SAC-30684: incremental child streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.2.0
+  * Updates "board_columns", "board_groups", "board_views", and "column_values" to be INCREMENTAL. [#21](https://github.com/singer-io/tap-monday/pull/21)
+
 ## 0.1.0
   * Updated python version. [#14](https://github.com/singer-io/tap-monday/pull/14)
   * Upgraded singer library version to latest.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.2.0
+## 1.0.0
   * Updates "board_columns", "board_groups", "board_views", and "column_values" to be INCREMENTAL. [#21](https://github.com/singer-io/tap-monday/pull/21)
 
 ## 0.1.0

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="tap-monday",
-      version="0.2.0",
+      version="1.0.0",
       description="Singer.io tap for extracting data from Monday API",
       author="Stitch",
       url="http://singer.io",

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="tap-monday",
-      version="0.1.0",
+      version="0.2.0",
       description="Singer.io tap for extracting data from Monday API",
       author="Stitch",
       url="http://singer.io",

--- a/tap_monday/schemas/board_columns.json
+++ b/tap_monday/schemas/board_columns.json
@@ -48,6 +48,13 @@
                 "null",
                 "string"
             ]
+        },
+        "updated_at": {
+            "type": [
+                "null",
+                "string"
+            ],
+            "format": "date-time"
         }
     }
 }

--- a/tap_monday/schemas/board_groups.json
+++ b/tap_monday/schemas/board_groups.json
@@ -42,6 +42,13 @@
                 "null",
                 "string"
             ]
+        },
+        "updated_at": {
+            "type": [
+                "null",
+                "string"
+            ],
+            "format": "date-time"
         }
     }
 }

--- a/tap_monday/schemas/board_views.json
+++ b/tap_monday/schemas/board_views.json
@@ -42,6 +42,13 @@
                 "null",
                 "string"
             ]
+        },
+        "updated_at": {
+            "type": [
+                "null",
+                "string"
+            ],
+            "format": "date-time"
         }
     }
 }

--- a/tap_monday/schemas/column_values.json
+++ b/tap_monday/schemas/column_values.json
@@ -51,6 +51,13 @@
                 "null",
                 "string"
             ]
+        },
+        "updated_at": {
+            "type": [
+                "null",
+                "string"
+            ],
+            "format": "date-time"
         }
     },
     "additionalProperties": true

--- a/tap_monday/streams/abstracts.py
+++ b/tap_monday/streams/abstracts.py
@@ -346,7 +346,7 @@ class IncrementalStream(BaseStream):
     def write_bookmark(self, state: dict, stream: str, key: Any = None, value: Any = None) -> Dict:
         """A wrapper for singer.get_bookmark to deal with compatibility for
         bookmark values or start values."""
-        if not (key or self.replication_keys):
+        if not (key or self.replication_keys) or self.parent:
             return state
 
         current_bookmark = get_bookmark(state, stream, key or self.replication_keys[0], self.client.config["start_date"])

--- a/tap_monday/streams/abstracts.py
+++ b/tap_monday/streams/abstracts.py
@@ -346,7 +346,7 @@ class IncrementalStream(BaseStream):
     def write_bookmark(self, state: dict, stream: str, key: Any = None, value: Any = None) -> Dict:
         """A wrapper for singer.get_bookmark to deal with compatibility for
         bookmark values or start values."""
-        if not (key or self.replication_keys) or self.parent:
+        if not (key or self.replication_keys):
             return state
 
         current_bookmark = get_bookmark(state, stream, key or self.replication_keys[0], self.client.config["start_date"])

--- a/tap_monday/streams/board_columns.py
+++ b/tap_monday/streams/board_columns.py
@@ -1,19 +1,19 @@
 from typing import Dict, List, Any
 from singer import get_logger
-from tap_monday.streams.abstracts import FullTableStream
+from tap_monday.streams.abstracts import IncrementalStream
 
 LOGGER = get_logger()
 
 
-class BoardColumns(FullTableStream):
+class BoardColumns(IncrementalStream):
     tap_stream_id = "board_columns"
     key_properties = ["id", "board_id"]
-    replication_method = "FULL_TABLE"
-    replication_keys = []
+    replication_method = "INCREMENTAL"
+    replication_keys = ["updated_at"]
     data_key = "data.boards"
     parent = "boards"
     root_field = "boards(ids: {ids}) {{ columns"
-    excluded_fields = ["board_id"]
+    excluded_fields = ["board_id", "updated_at"]
 
     def update_data_payload(self, graphql_query: str = None, parent_obj: Dict = None, **kwargs) -> None:
         """
@@ -29,6 +29,7 @@ class BoardColumns(FullTableStream):
         """Modify the record before writing to the stream."""
         record = super().modify_object(record, parent_record)
         record["board_id"] = parent_record.get("id")
+        record["updated_at"] = parent_record.get("updated_at")
         return record
 
     def parse_raw_records(self, raw_data: Any) -> List[Dict]:

--- a/tap_monday/streams/board_columns.py
+++ b/tap_monday/streams/board_columns.py
@@ -36,3 +36,5 @@ class BoardColumns(IncrementalStream):
         """Custom parsing for streams that return data[0]['columns']."""
         return raw_data[0].get("columns", []) if raw_data else []
 
+    def write_bookmark(self, state: dict, stream: str, key: Any = None, value: Any = None) -> Dict:
+        return state

--- a/tap_monday/streams/board_groups.py
+++ b/tap_monday/streams/board_groups.py
@@ -34,3 +34,5 @@ class BoardGroups(IncrementalStream):
         """Custom parsing for streams that return data[0]['groups']."""
         return raw_data[0].get("groups", []) if raw_data else []
 
+    def write_bookmark(self, state: dict, stream: str, key: Any = None, value: Any = None) -> Dict:
+        return state

--- a/tap_monday/streams/board_groups.py
+++ b/tap_monday/streams/board_groups.py
@@ -1,19 +1,19 @@
 from typing import Dict, List, Any
 from singer import get_logger
-from tap_monday.streams.abstracts import FullTableStream
+from tap_monday.streams.abstracts import IncrementalStream
 
 LOGGER = get_logger()
 
 
-class BoardGroups(FullTableStream):
+class BoardGroups(IncrementalStream):
     tap_stream_id = "board_groups"
     key_properties = ["id", "board_id"]
-    replication_method = "FULL_TABLE"
-    replication_keys = []
+    replication_method = "INCREMENTAL"
+    replication_keys = ["updated_at"]
     data_key = "data.boards"
     parent = "boards"
     root_field = "boards(ids: {ids}) {{ groups"
-    excluded_fields = ["board_id"]
+    excluded_fields = ["board_id", "updated_at"]
 
     def update_data_payload(self, graphql_query: str = None, parent_obj: Dict = None, **kwargs) -> None:
         """Update JSON body for GraphQL API. Injects query string if provided."""
@@ -27,6 +27,7 @@ class BoardGroups(FullTableStream):
         """Modify the record before writing to the stream."""
         record = super().modify_object(record, parent_record)
         record["board_id"] = parent_record.get("id")
+        record["updated_at"] = parent_record.get("updated_at")
         return record
 
     def parse_raw_records(self, raw_data: Any) -> List[Dict]:

--- a/tap_monday/streams/board_views.py
+++ b/tap_monday/streams/board_views.py
@@ -1,19 +1,19 @@
 from typing import Dict, List, Any
 from singer import get_logger
-from tap_monday.streams.abstracts import FullTableStream
+from tap_monday.streams.abstracts import IncrementalStream
 
 LOGGER = get_logger()
 
 
-class BoardViews(FullTableStream):
+class BoardViews(IncrementalStream):
     tap_stream_id = "board_views"
     key_properties = ["id", "board_id"]
-    replication_method = "FULL_TABLE"
-    replication_keys = []
+    replication_method = "INCREMENTAL"
+    replication_keys = ["updated_at"]
     data_key = "data.boards"
     parent = "boards"
     root_field = "boards(ids: {ids}) {{ views"
-    excluded_fields = ["board_id"]
+    excluded_fields = ["board_id", "updated_at"]
 
     def update_data_payload(self, graphql_query: str = None, parent_obj: Dict = None, **kwargs) -> None:
         """
@@ -29,9 +29,9 @@ class BoardViews(FullTableStream):
         """Modify the record before writing to the stream."""
         record = super().modify_object(record, parent_record)
         record["board_id"] = parent_record.get("id")
+        record["updated_at"] = parent_record.get("updated_at")
         return record
 
     def parse_raw_records(self, raw_data: Any) -> List[Dict]:
         """Custom parsing for streams that return data[0]['groups']."""
         return raw_data[0].get("views", []) if raw_data else []
-

--- a/tap_monday/streams/board_views.py
+++ b/tap_monday/streams/board_views.py
@@ -35,3 +35,6 @@ class BoardViews(IncrementalStream):
     def parse_raw_records(self, raw_data: Any) -> List[Dict]:
         """Custom parsing for streams that return data[0]['groups']."""
         return raw_data[0].get("views", []) if raw_data else []
+
+    def write_bookmark(self, state: dict, stream: str, key: Any = None, value: Any = None) -> Dict:
+        return state

--- a/tap_monday/streams/boards.py
+++ b/tap_monday/streams/boards.py
@@ -1,5 +1,8 @@
 from typing import Dict, Any
-from singer import get_logger
+from singer import (
+    get_bookmark,
+    get_logger
+)
 from tap_monday.streams.abstracts import IncrementalStream, ParentChildBookmarkMixin
 
 LOGGER = get_logger()
@@ -31,3 +34,12 @@ class Boards(ParentChildBookmarkMixin, IncrementalStream):
         graphql_query = self.get_graphql_query(root_field)
         super().update_data_payload(graphql_query=graphql_query, parent_obj=parent_obj, **kwargs)
 
+    def get_bookmark(self, state: dict, stream: str, key: Any = None) -> int:
+        """A wrapper for singer.get_bookmark to deal with compatibility for
+        bookmark values or start values."""
+        return get_bookmark(
+            state,
+            stream,
+            key or self.replication_keys[0],
+            self.client.config["start_date"],
+        )

--- a/tap_monday/streams/column_values.py
+++ b/tap_monday/streams/column_values.py
@@ -1,19 +1,19 @@
 from typing import Dict, Any, List
 from singer import get_logger
-from tap_monday.streams.abstracts import FullTableStream
+from tap_monday.streams.abstracts import IncrementalStream
 
 LOGGER = get_logger()
 
 
-class ColumnValues(FullTableStream):
+class ColumnValues(IncrementalStream):
     tap_stream_id = "column_values"
     key_properties = ["id", "item_id", "board_id"]
-    replication_method = "FULL_TABLE"
-    replication_keys = []
+    replication_method = "INCREMENTAL"
+    replication_keys = ["updated_at"]
     data_key = "data.items"
     parent = "board_items"
     root_field = "items (ids: {ids}) {{ column_values"
-    excluded_fields = ["item_id", "board_id"]
+    excluded_fields = ["item_id", "board_id", "updated_at"]
 
     def update_data_payload(self, graphql_query: str = None, parent_obj: Dict = None, **kwargs) -> None:
         """
@@ -30,6 +30,7 @@ class ColumnValues(FullTableStream):
         record = super().modify_object(record, parent_record)
         record["item_id"] = parent_record.get("id")
         record["board_id"] = parent_record.get("board_id")
+        record["updated_at"] = parent_record.get("updated_at")
         return record
 
     def parse_raw_records(self, raw_data: Any) -> List[Dict]:

--- a/tap_monday/streams/column_values.py
+++ b/tap_monday/streams/column_values.py
@@ -37,3 +37,5 @@ class ColumnValues(IncrementalStream):
         """Custom parsing for streams that return data[0]['columns']."""
         return raw_data[0].get("column_values") if raw_data else []
 
+    def write_bookmark(self, state: dict, stream: str, key: Any = None, value: Any = None) -> Dict:
+        return state

--- a/tests/base.py
+++ b/tests/base.py
@@ -70,15 +70,15 @@ class MondayBaseTest(BaseCase):
             },
             "board_columns": {
                 cls.PRIMARY_KEYS: { "id", "board_id" },
-                cls.REPLICATION_METHOD: cls.FULL_TABLE,
-                cls.REPLICATION_KEYS: set(),
+                cls.REPLICATION_METHOD: cls.INCREMENTAL,
+                cls.REPLICATION_KEYS: { "updated_at" },
                 cls.RESPECTS_START_DATE: False,
                 cls.API_LIMIT: 1
             },
             "board_groups": {
                 cls.PRIMARY_KEYS: { "id", "board_id" },
-                cls.REPLICATION_METHOD: cls.FULL_TABLE,
-                cls.REPLICATION_KEYS: set(),
+                cls.REPLICATION_METHOD: cls.INCREMENTAL,
+                cls.REPLICATION_KEYS: { "updated_at" },
                 cls.RESPECTS_START_DATE: False,
                 cls.API_LIMIT: 1
             },
@@ -91,15 +91,15 @@ class MondayBaseTest(BaseCase):
             },
             "board_views": {
                 cls.PRIMARY_KEYS: { "id", "board_id" },
-                cls.REPLICATION_METHOD: cls.FULL_TABLE,
-                cls.REPLICATION_KEYS: set(),
+                cls.REPLICATION_METHOD: cls.INCREMENTAL,
+                cls.REPLICATION_KEYS: { "updated_at" },
                 cls.RESPECTS_START_DATE: False,
                 cls.API_LIMIT: 1
             },
             "column_values": {
                 cls.PRIMARY_KEYS: { "id", "item_id", "board_id" },
-                cls.REPLICATION_METHOD: cls.FULL_TABLE,
-                cls.REPLICATION_KEYS: set(),
+                cls.REPLICATION_METHOD: cls.INCREMENTAL,
+                cls.REPLICATION_KEYS: { "updated_at" },
                 cls.RESPECTS_START_DATE: False,
                 cls.API_LIMIT: 1
             },


### PR DESCRIPTION
# Description of change
https://qlik-dev.atlassian.net/browse/SAC-30684
- Make `board_groups`, `board_views`, `board_columns`, and `column_values` `INCREMENTAL` streams
- Skips writing bookmarks for these streams (the parent writes bookmarks for its children [here](https://github.com/singer-io/tap-monday/blob/f1f7f0ef297dd51828fdbc26216a6dedf6e37123/tap_monday/streams/abstracts.py#L455-L462))
- `boards` no longer reads children bookmarks (happening [here](https://github.com/singer-io/tap-monday/blob/f1f7f0ef297dd51828fdbc26216a6dedf6e37123/tap_monday/streams/abstracts.py#L430-L446)) when computing its own bookmark

Example State:
```json
{
  "bookmarks": {
    "reply": {
      "updates_updated_at": "2025-05-05T00:00:00Z"
    },
    "boards": {
      "updated_at": "2026-03-19T08:43:23.000000Z"
    },
    "updates": {
      "updated_at": "2025-05-05T00:00:00Z"
    },
    "board_items": {
      "updated_at": "2026-03-19T08:43:26.000000Z",
      "boards_updated_at": "2026-03-19T08:43:23.000000Z"
    },
    "board_views": {
      "boards_updated_at": "2026-03-19T08:43:23.000000Z"
    },
    "board_groups": {
      "boards_updated_at": "2026-03-19T08:43:23.000000Z"
    },
    "platform_api": {
      "last_updated": "2026-05-05T20:50:23.433000Z"
    },
    "board_columns": {
      "boards_updated_at": "2026-03-19T08:43:23.000000Z"
    },
    "column_values": {
      "board_items_updated_at": "2026-03-19T08:43:26.000000Z"
    },
    "board_activity_logs": {
      "created_at": "2026-03-19T08:43:23.289000Z",
      "boards_updated_at": "2026-03-19T08:43:23.000000Z"
    }
  },
  "target_state": {
    "docs": "fullLoadEnd",
    "tags": "fullLoadEnd",
    "reply": "incrementalLoadEnd",
    "teams": "fullLoadEnd",
    "users": "fullLoadEnd",
    "assets": "fullLoadEnd",
    "boards": "incrementalLoadEnd",
    "account": "fullLoadEnd",
    "folders": "fullLoadEnd",
    "updates": "incrementalLoadEnd",
    "workspaces": "fullLoadEnd",
    "board_items": "incrementalLoadEnd",
    "board_views": "incrementalLoadEnd",
    "board_groups": "incrementalLoadEnd",
    "platform_api": "incrementalLoadEnd",
    "board_columns": "incrementalLoadEnd",
    "column_values": "incrementalLoadEnd",
    "board_activity_logs": "incrementalLoadEnd",
    "audit_event_catalogue": "fullLoadEnd"
  },
  "target_total_batches": {
  }
}
```

# Manual QA steps
 - did initial sync
 - update board_group
 - ran another sync and verified board.updated_at changed
 - updated board_item
 - ran another sync and verified board.updated_at changed
 - added board_column
 - ran another sync and verified board.updated_at changed
 - added board_view
  - ran another sync and verified board.updated_at changed
  - updated column_value
  - ran another sync and verified board_item.updated_at changed
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
