### PR TITLE
SAC-30834: validate API token during discovery

### DIFF
--- a/tap_monday/__init__.py
+++ b/tap_monday/__init__.py
@@ -31,6 +31,7 @@ def main():
 
     with Client(parsed_args.config) as client:
         if parsed_args.discover:
+            client.check_access()
             do_discover()
         elif parsed_args.catalog:
             sync(

--- a/tap_monday/client.py
+++ b/tap_monday/client.py
@@ -1,4 +1,5 @@
 from typing import Any, Dict, Mapping, Optional, Tuple
+import json
 import time
 
 import backoff
@@ -97,6 +98,15 @@ class Client:
 
     def __exit__(self, exception_type, exception_value, traceback):
         self._session.close()
+
+    def check_access(self):
+        """Validate the API token by making a lightweight authenticated request.
+
+        Raises MondayUnauthorizedError (401) or MondayForbiddenError (403) if
+        the token is invalid or lacks required permissions.
+        """
+        body = json.dumps({"query": "query { me { id } }"})
+        self.make_request("POST", self.base_url, body=body)
 
     @property
     def headers(self) -> Dict[str, str]:

--- a/tests/unittests/test_client.py
+++ b/tests/unittests/test_client.py
@@ -7,7 +7,8 @@ from tap_monday.client import Client, raise_for_error, wait_if_retry_after
 from tap_monday.exceptions import (
     ERROR_CODE_EXCEPTION_MAPPING,
     MondayError,
-    MondayRateLimitError
+    MondayRateLimitError,
+    MondayUnauthorizedError
 )
 
 
@@ -131,6 +132,39 @@ class TestClientMakeRequest(unittest.TestCase):
                 self.assertEqual(result, expected_result)
 
             self.assertEqual(mock_request.call_count, len(side_effects))
+
+
+class TestCheckAccess(unittest.TestCase):
+    """Test the Client.check_access() token validation method."""
+
+    def setUp(self):
+        self.config = {
+            "api_token": "dummy_token",
+            "start_date": "2019-01-01T00:00:00Z",
+            "user_agent": "tap-monday test@test.com",
+            "api_version": "2025-07",
+            "request_timeout": 300
+        }
+        self.client = Client(self.config)
+
+    def test_check_access_valid_token(self):
+        """check_access succeeds without error when the token is valid."""
+        mock_response = MockResponse(200, {"data": {"me": {"id": "12345"}}})
+        with patch("requests.Session.request", return_value=mock_response) as mock_request:
+            self.client.check_access()
+            mock_request.assert_called_once()
+            # Verify it sent the me query
+            call_kwargs = mock_request.call_args
+            self.assertIn("me", call_kwargs.kwargs.get("data", "") or call_kwargs[1].get("data", ""))
+
+    def test_check_access_invalid_token(self):
+        """check_access raises MondayUnauthorizedError when the token is invalid."""
+        mock_response = MockResponse(
+            401,
+            {"errors": [{"message": "Not Authenticated", "extensions": {"code": "Unauthorized"}}]})
+        with patch("requests.Session.request", return_value=mock_response):
+            with self.assertRaises(MondayUnauthorizedError):
+                self.client.check_access()
 
 
 class TestWaitIfRetryAfter(unittest.TestCase):


### PR DESCRIPTION
# Description of change

[SAC-30834](https://qlik-dev.atlassian.net/browse/SAC-30834) - Discovery succeeds with invalid token.

Discovery was a purely offline operation - it read static JSON schemas from disk and never hit the Monday.com API. A connection created with a bad token would pass discovery and only fail on the first sync.

Add `Client.check_access()` that sends a lightweight `query { me { id } }` request before discovery runs. Invalid tokens now fail immediately with `MondayUnauthorizedError` (401).

# Manual QA steps
- Create a tap-monday connection with an invalid/revoked API token
- Run discovery (`tap-monday --config config.json --discover`)
- Verify it exits 1 with `CRITICAL HTTP-error-code: 401, Error: Not authenticated`
- Create a connection with a valid token
- Verify discovery succeeds and emits a catalog as before

# Risks
- Adds one extra API call (`query { me { id } }`) per discovery run. Negligible cost, and `me` is the cheapest Monday.com endpoint.
- If Monday.com API is temporarily unreachable, discovery will fail where it previously succeeded offline. This is acceptable - a token that can't reach the API isn't useful anyway.

# Rollback steps
- revert this branch