### PR TITLE
Fix for SchemaMismatch issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# Changelog
+
+## 1.1.0
+  * Fixed `SchemaMismatch` on `workspaces` stream — allow null array items in `workspaces`, `docs`, `folders`, `platform_api`, `reply`, and `teams` schemas. [#23](https://github.com/singer-io/tap-monday/pull/23)
+  * Fixed set operator precedence bug in `_process_properties` and `KeyError` risk in `add_object_to_id`.
+  * Added discovery unit tests.
+  * Bumped requests module version.
+
 ## 1.0.0
   * Updates "board_columns", "board_groups", "board_views", and "column_values" to be INCREMENTAL. [#21](https://github.com/singer-io/tap-monday/pull/21)
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="tap-monday",
-      version="1.0.0",
+      version="1.1.0",
       description="Singer.io tap for extracting data from Monday API",
       author="Stitch",
       url="http://singer.io",
@@ -12,7 +12,7 @@ setup(name="tap-monday",
       py_modules=["tap_monday"],
       install_requires=[
           "singer-python==6.8.0",
-          "requests==2.33.0",
+          "requests==2.34.2",
           "backoff==2.2.1",
       ],
       extras_require={

--- a/tap_monday/schemas/docs.json
+++ b/tap_monday/schemas/docs.json
@@ -37,7 +37,10 @@
                 "array"
             ],
             "items": {
-                "type": "object",
+                "type": [
+                    "null",
+                    "object"
+                ],
                 "properties": {
                     "id": {
                         "type": [

--- a/tap_monday/schemas/folders.json
+++ b/tap_monday/schemas/folders.json
@@ -50,7 +50,10 @@
                 "array"
             ],
             "items": {
-                "type": "object",
+                "type": [
+                    "null",
+                    "object"
+                ],
                 "properties": {
                     "id": {
                         "type": [
@@ -74,7 +77,10 @@
                 "array"
             ],
             "items": {
-                "type": "object",
+                "type": [
+                    "null",
+                    "object"
+                ],
                 "properties": {
                     "id": {
                         "type": [

--- a/tap_monday/schemas/platform_api.json
+++ b/tap_monday/schemas/platform_api.json
@@ -34,7 +34,10 @@
                         "array"
                     ],
                     "items": {
-                        "type": "object",
+                        "type": [
+                            "null",
+                            "object"
+                        ],
                         "properties": {
                             "day": {
                                 "type": [
@@ -58,7 +61,10 @@
                         "array"
                     ],
                     "items": {
-                        "type": "object",
+                        "type": [
+                            "null",
+                            "object"
+                        ],
                         "properties": {
                             "app": {
                                 "type": [
@@ -96,14 +102,17 @@
                         "array"
                     ],
                     "items": {
-                        "type": "object",
+                        "type": [
+                            "null",
+                            "object"
+                        ],
                         "properties": {
                             "user": {
                                 "type": [
                                     "null",
                                     "object"
                                 ],
-                                "properties":{
+                                "properties": {
                                     "id": {
                                         "type": [
                                             "null",

--- a/tap_monday/schemas/reply.json
+++ b/tap_monday/schemas/reply.json
@@ -25,7 +25,10 @@
                 "array"
             ],
             "items": {
-                "type": "object",
+                "type": [
+                    "null",
+                    "object"
+                ],
                 "properties": {
                     "id": {
                         "type": [
@@ -75,7 +78,10 @@
                 "array"
             ],
             "items": {
-                "type": "object",
+                "type": [
+                    "null",
+                    "object"
+                ],
                 "properties": {
                     "id": {
                         "type": [
@@ -132,7 +138,10 @@
                 "array"
             ],
             "items": {
-                "type": "object",
+                "type": [
+                    "null",
+                    "object"
+                ],
                 "properties": {
                     "user_id": {
                         "type": [

--- a/tap_monday/schemas/teams.json
+++ b/tap_monday/schemas/teams.json
@@ -25,7 +25,10 @@
                 "array"
             ],
             "items": {
-                "type": "object",
+                "type": [
+                    "null",
+                    "object"
+                ],
                 "properties": {
                     "id": {
                         "type": [
@@ -49,7 +52,10 @@
                 "array"
             ],
             "items": {
-                "type": "object",
+                "type": [
+                    "null",
+                    "object"
+                ],
                 "properties": {
                     "id": {
                         "type": [

--- a/tap_monday/schemas/workspaces.json
+++ b/tap_monday/schemas/workspaces.json
@@ -107,7 +107,10 @@
                 "array"
             ],
             "items": {
-                "type": "object",
+                "type": [
+                    "null",
+                    "object"
+                ],
                 "properties": {
                     "id": {
                         "type": [
@@ -131,7 +134,10 @@
                 "array"
             ],
             "items": {
-                "type": "object",
+                "type": [
+                    "null",
+                    "object"
+                ],
                 "properties": {
                     "id": {
                         "type": [
@@ -155,7 +161,10 @@
                 "array"
             ],
             "items": {
-                "type": "object",
+                "type": [
+                    "null",
+                    "object"
+                ],
                 "properties": {
                     "id": {
                         "type": [

--- a/tap_monday/streams/abstracts.py
+++ b/tap_monday/streams/abstracts.py
@@ -139,8 +139,9 @@ class BaseStream(ABC):
         Adds identifier fields to a record based on nested object mappings.
         """
         for key in self.object_to_id:
-            if record[key]:
-                record[self.object_to_id[key] + "_id"] = record[key]["id"]
+            value = record.get(key)
+            if value:
+                record[self.object_to_id[key] + "_id"] = value["id"]
             else:
                 record[key + "_id"] = None
         return record
@@ -244,7 +245,7 @@ class BaseStream(ABC):
 
         schema_keys = set(properties.keys() if properties else [])
         extra_keys = set(extras_branch.keys()) if extras_branch else set()
-        all_keys = sorted(schema_keys | extra_keys - {"_extras"})
+        all_keys = sorted((schema_keys | extra_keys) - {"_extras"})
 
         all_keys = [
             key for key in all_keys

--- a/tap_monday/streams/abstracts.py
+++ b/tap_monday/streams/abstracts.py
@@ -139,11 +139,12 @@ class BaseStream(ABC):
         Adds identifier fields to a record based on nested object mappings.
         """
         for key in self.object_to_id:
+            mapped_id_field = self.object_to_id[key] + "_id"
             value = record.get(key)
             if value:
-                record[self.object_to_id[key] + "_id"] = value["id"]
+                record[mapped_id_field] = value["id"]
             else:
-                record[key + "_id"] = None
+                record[mapped_id_field] = None
         return record
 
     def modify_object(self, record: Dict, parent_record: Dict = None) -> Dict:

--- a/tests/unittests/test_discovery.py
+++ b/tests/unittests/test_discovery.py
@@ -1,0 +1,380 @@
+"""Unit tests for tap_monday discovery — discover() and get_schemas().
+
+Covers:
+  1.  discover() returns a singer Catalog whose entries map 1-to-1 with STREAMS.
+  2.  Every CatalogEntry carries the right stream name, tap_stream_id,
+      key_properties, schema, and metadata.
+  3.  Replication method and key-properties are reflected in the entry metadata.
+  4.  Field-level inclusion metadata (available / automatic) is present.
+  5.  A schema file exists on disk for every stream registered in STREAMS.
+  6.  Every schema file is valid JSON with a root "type": "object".
+  7.  Regression: array items in schemas must allow null
+      ("type": ["null","object"]) — the class of bug that caused the prod
+      workspaces SchemaMismatch crash.
+  8.  get_schemas() returns entries for every STREAMS key.
+  9.  discover() propagates exceptions raised by get_schemas().
+  10. Schema properties match the corresponding CatalogEntry schema fields.
+"""
+
+import json
+import os
+import unittest
+from unittest.mock import MagicMock, patch
+
+from singer.catalog import Catalog, CatalogEntry
+
+from tap_monday.discover import discover
+from tap_monday.schema import get_schemas, get_abs_path
+from tap_monday.streams import STREAMS
+
+SCHEMAS_DIR = get_abs_path("schemas")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _load_all_schemas():
+    """Return {stream_name: schema_dict} for every file in the schemas dir."""
+    result = {}
+    for stream_name in STREAMS:
+        path = os.path.join(SCHEMAS_DIR, f"{stream_name}.json")
+        if os.path.exists(path):
+            with open(path) as fh:
+                result[stream_name] = json.load(fh)
+    return result
+
+
+def _collect_bad_items(schema, path=""):
+    """
+    Recursively walk *schema* and return a list of dot-paths where an array's
+    items schema has "object" in its type but NOT "null".
+
+    These are the places that will cause singer SchemaMismatch when the API
+    returns a null entry inside an array (e.g. teams_subscribers: [null, ...]).
+    """
+    issues = []
+    if not isinstance(schema, dict):
+        return issues
+
+    raw_type = schema.get("type", [])
+    schema_types = [raw_type] if isinstance(raw_type, str) else raw_type
+
+    if "array" in schema_types:
+        items = schema.get("items", {})
+        if items:
+            raw_item_type = items.get("type", [])
+            item_types = [raw_item_type] if isinstance(raw_item_type, str) else raw_item_type
+            if "object" in item_types and "null" not in item_types:
+                issues.append(f"{path}.items" if path else "items")
+            # Recurse into item properties
+            for prop, prop_schema in items.get("properties", {}).items():
+                child_path = f"{path}.items.{prop}" if path else f"items.{prop}"
+                issues.extend(_collect_bad_items(prop_schema, child_path))
+
+    # Recurse into object properties
+    for prop, prop_schema in schema.get("properties", {}).items():
+        child_path = f"{path}.{prop}" if path else prop
+        issues.extend(_collect_bad_items(prop_schema, child_path))
+
+    return issues
+
+
+# ---------------------------------------------------------------------------
+# 1 – discover() structure
+# ---------------------------------------------------------------------------
+
+class TestDiscoverReturnsCatalog(unittest.TestCase):
+    """discover() must return a populated singer Catalog."""
+
+    def test_returns_catalog_instance(self):
+        catalog = discover()
+        self.assertIsInstance(catalog, Catalog)
+
+    def test_catalog_has_all_streams(self):
+        catalog = discover()
+        catalog_stream_names = {entry.stream for entry in catalog.streams}
+        self.assertEqual(catalog_stream_names, set(STREAMS.keys()))
+
+    def test_no_duplicate_streams(self):
+        catalog = discover()
+        names = [entry.stream for entry in catalog.streams]
+        self.assertEqual(len(names), len(set(names)),
+                         "discover() produced duplicate catalog entries")
+
+
+# ---------------------------------------------------------------------------
+# 2 & 3 – CatalogEntry fields
+# ---------------------------------------------------------------------------
+
+class TestCatalogEntryFields(unittest.TestCase):
+    """Each CatalogEntry must carry correctly-populated fields."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.catalog = discover()
+        cls.entries = {e.stream: e for e in cls.catalog.streams}
+
+    def test_stream_equals_tap_stream_id(self):
+        for name, entry in self.entries.items():
+            with self.subTest(stream=name):
+                self.assertEqual(entry.stream, entry.tap_stream_id)
+
+    def test_key_properties_match_stream_class(self):
+        for name, entry in self.entries.items():
+            expected = list(STREAMS[name].key_properties)
+            with self.subTest(stream=name):
+                self.assertEqual(list(entry.key_properties), expected)
+
+    def test_schema_is_not_empty(self):
+        for name, entry in self.entries.items():
+            with self.subTest(stream=name):
+                schema_dict = entry.schema.to_dict()
+                self.assertIn("properties", schema_dict,
+                              f"Schema for '{name}' has no 'properties' key")
+                self.assertGreater(len(schema_dict["properties"]), 0)
+
+    def test_metadata_is_not_empty(self):
+        for name, entry in self.entries.items():
+            with self.subTest(stream=name):
+                self.assertIsNotNone(entry.metadata)
+                self.assertGreater(len(entry.metadata), 0)
+
+    def test_replication_method_in_metadata(self):
+        from singer import metadata as md
+        for name, entry in self.entries.items():
+            mdata_map = md.to_map(entry.metadata)
+            replication_method = mdata_map.get((), {}).get("forced-replication-method")
+            with self.subTest(stream=name):
+                self.assertIsNotNone(
+                    replication_method,
+                    f"'forced-replication-method' missing in root metadata for '{name}'"
+                )
+                self.assertEqual(
+                    replication_method.upper(),
+                    STREAMS[name].replication_method.upper()
+                )
+
+
+# ---------------------------------------------------------------------------
+# 4 – Field inclusion metadata
+# ---------------------------------------------------------------------------
+
+class TestFieldInclusionMetadata(unittest.TestCase):
+    """Every schema field must have an 'inclusion' value in metadata."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.catalog = discover()
+
+    def test_all_fields_have_inclusion(self):
+        from singer import metadata as md
+        valid_inclusions = {"available", "automatic", "unsupported"}
+        for entry in self.catalog.streams:
+            mdata_map = md.to_map(entry.metadata)
+            schema_props = entry.schema.to_dict().get("properties", {})
+            for field_name in schema_props:
+                breadcrumb = ("properties", field_name)
+                inclusion = mdata_map.get(breadcrumb, {}).get("inclusion")
+                with self.subTest(stream=entry.stream, field=field_name):
+                    self.assertIn(
+                        inclusion, valid_inclusions,
+                        f"'{entry.stream}.{field_name}' has invalid inclusion '{inclusion}'"
+                    )
+
+    def test_replication_keys_are_automatic(self):
+        from singer import metadata as md
+        for name, stream_cls in STREAMS.items():
+            if not stream_cls.replication_keys:
+                continue
+            catalog = discover()
+            entries = {e.stream: e for e in catalog.streams}
+            entry = entries[name]
+            mdata_map = md.to_map(entry.metadata)
+            for key in stream_cls.replication_keys:
+                breadcrumb = ("properties", key)
+                inclusion = mdata_map.get(breadcrumb, {}).get("inclusion")
+                with self.subTest(stream=name, field=key):
+                    self.assertEqual(
+                        inclusion, "automatic",
+                        f"Replication key '{key}' in '{name}' should be 'automatic', got '{inclusion}'"
+                    )
+
+
+# ---------------------------------------------------------------------------
+# 5 & 6 – Schema files on disk
+# ---------------------------------------------------------------------------
+
+class TestSchemaFiles(unittest.TestCase):
+    """Schema files must exist and be valid JSON with a root object type."""
+
+    def test_schema_file_exists_for_every_stream(self):
+        for stream_name in STREAMS:
+            path = os.path.join(SCHEMAS_DIR, f"{stream_name}.json")
+            with self.subTest(stream=stream_name):
+                self.assertTrue(
+                    os.path.exists(path),
+                    f"Schema file missing for stream '{stream_name}': {path}"
+                )
+
+    def test_schema_files_are_valid_json(self):
+        for stream_name in STREAMS:
+            path = os.path.join(SCHEMAS_DIR, f"{stream_name}.json")
+            if not os.path.exists(path):
+                continue
+            with self.subTest(stream=stream_name):
+                try:
+                    with open(path) as fh:
+                        schema = json.load(fh)
+                except json.JSONDecodeError as exc:
+                    self.fail(f"Invalid JSON in '{path}': {exc}")
+
+    def test_schema_root_is_object_type(self):
+        for stream_name in STREAMS:
+            path = os.path.join(SCHEMAS_DIR, f"{stream_name}.json")
+            if not os.path.exists(path):
+                continue
+            with open(path) as fh:
+                schema = json.load(fh)
+            with self.subTest(stream=stream_name):
+                self.assertEqual(
+                    schema.get("type"), "object",
+                    f"Root type of '{stream_name}' schema must be 'object'"
+                )
+
+    def test_schema_has_properties(self):
+        for stream_name in STREAMS:
+            path = os.path.join(SCHEMAS_DIR, f"{stream_name}.json")
+            if not os.path.exists(path):
+                continue
+            with open(path) as fh:
+                schema = json.load(fh)
+            with self.subTest(stream=stream_name):
+                self.assertIn("properties", schema,
+                              f"Schema for '{stream_name}' missing 'properties'")
+                self.assertGreater(len(schema["properties"]), 0)
+
+
+# ---------------------------------------------------------------------------
+# 7 – Regression: array items must allow null
+# ---------------------------------------------------------------------------
+
+class TestSchemaArrayItemsAllowNull(unittest.TestCase):
+    """
+    Regression test for the prod workspaces crash.
+
+    Every array whose items type includes 'object' must also include 'null'
+    so that singer's transform does not raise SchemaMismatch when the Monday
+    API returns a null entry inside the array (e.g. a deleted team still
+    referenced in teams_subscribers).
+    """
+
+    def test_all_array_items_allow_null(self):
+        all_schemas = _load_all_schemas()
+        for stream_name, schema in all_schemas.items():
+            bad_paths = _collect_bad_items(schema)
+            with self.subTest(stream=stream_name):
+                self.assertEqual(
+                    bad_paths, [],
+                    f"Stream '{stream_name}' has array items that don't allow null "
+                    f"(missing 'null' in type). Affected paths: {bad_paths}. "
+                    f"Fix: change \"type\": \"object\" to \"type\": [\"null\", \"object\"] "
+                    f"for those items schemas."
+                )
+
+
+# ---------------------------------------------------------------------------
+# 8 – get_schemas() structure
+# ---------------------------------------------------------------------------
+
+class TestGetSchemas(unittest.TestCase):
+    """get_schemas() must return correctly structured dicts for all streams."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.schemas, cls.field_metadata = get_schemas()
+
+    def test_returns_all_streams(self):
+        self.assertEqual(set(self.schemas.keys()), set(STREAMS.keys()))
+
+    def test_field_metadata_keys_match_streams(self):
+        self.assertEqual(set(self.field_metadata.keys()), set(STREAMS.keys()))
+
+    def test_each_schema_is_dict(self):
+        for name, schema in self.schemas.items():
+            with self.subTest(stream=name):
+                self.assertIsInstance(schema, dict)
+
+    def test_each_field_metadata_is_list(self):
+        for name, mdata in self.field_metadata.items():
+            with self.subTest(stream=name):
+                self.assertIsInstance(mdata, list,
+                                      f"field_metadata['{name}'] should be a list")
+
+    def test_key_properties_in_metadata(self):
+        from singer import metadata as md
+        for name, mdata in self.field_metadata.items():
+            mdata_map = md.to_map(mdata)
+            key_props = mdata_map.get((), {}).get("table-key-properties")
+            with self.subTest(stream=name):
+                self.assertIsNotNone(
+                    key_props,
+                    f"'table-key-properties' missing in root metadata for '{name}'"
+                )
+                self.assertEqual(
+                    key_props,
+                    list(STREAMS[name].key_properties)
+                )
+
+
+# ---------------------------------------------------------------------------
+# 9 – Error propagation
+# ---------------------------------------------------------------------------
+
+class TestDiscoverErrorHandling(unittest.TestCase):
+    """discover() must propagate errors raised by get_schemas()."""
+
+    @patch("tap_monday.discover.get_schemas", side_effect=FileNotFoundError("missing schema"))
+    def test_propagates_file_not_found(self, _mock):
+        with self.assertRaises(FileNotFoundError):
+            discover()
+
+    @patch("tap_monday.discover.get_schemas", side_effect=json.JSONDecodeError("bad json", "", 0))
+    def test_propagates_json_decode_error(self, _mock):
+        with self.assertRaises(json.JSONDecodeError):
+            discover()
+
+    @patch("tap_monday.discover.get_schemas")
+    def test_propagates_schema_key_error(self, mock_get_schemas):
+        # Simulate a stream whose schema dict raises KeyError on Schema.from_dict
+        mock_get_schemas.return_value = (
+            {"bad_stream": None},    # None will cause Schema.from_dict to fail
+            {"bad_stream": []}
+        )
+        with self.assertRaises(Exception):
+            discover()
+
+
+# ---------------------------------------------------------------------------
+# 10 – Schema properties ↔ CatalogEntry consistency
+# ---------------------------------------------------------------------------
+
+class TestSchemaPropertyConsistency(unittest.TestCase):
+    """CatalogEntry schema properties must match the raw schema files."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.catalog = discover()
+        cls.entries = {e.stream: e for e in cls.catalog.streams}
+        cls.raw_schemas = _load_all_schemas()
+
+    def test_catalog_schema_properties_match_raw_file(self):
+        for name, entry in self.entries.items():
+            raw = self.raw_schemas.get(name, {})
+            expected_fields = set(raw.get("properties", {}).keys())
+            actual_fields = set(entry.schema.to_dict().get("properties", {}).keys())
+            with self.subTest(stream=name):
+                self.assertEqual(
+                    actual_fields, expected_fields,
+                    f"CatalogEntry schema properties for '{name}' differ from raw schema file"
+                )

--- a/tests/unittests/test_discovery.py
+++ b/tests/unittests/test_discovery.py
@@ -19,9 +19,9 @@ Covers:
 import json
 import os
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
-from singer.catalog import Catalog, CatalogEntry
+from singer.catalog import Catalog
 
 from tap_monday.discover import discover
 from tap_monday.schema import get_schemas, get_abs_path
@@ -225,7 +225,7 @@ class TestSchemaFiles(unittest.TestCase):
             with self.subTest(stream=stream_name):
                 try:
                     with open(path) as fh:
-                        schema = json.load(fh)
+                        json.load(fh)
                 except json.JSONDecodeError as exc:
                     self.fail(f"Invalid JSON in '{path}': {exc}")
 


### PR DESCRIPTION
# Description of change
PR include fix for production issue the workspaces stream was crashing with a [singer.transform.SchemaMismatch] error on teams_subscribers.0.
This bug was invisible locally because test accounts had no teams subscribed, resulting in teams_subscribers: [] — an empty array has no items to validate. [SAC-30847](https://qlik-dev.atlassian.net/browse/SAC-30847)

# Manual QA steps
- [x]  Discovery: running
- [x]  Sync: running
- [x]  Unit Tests: running
- [x]  Integration test
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
