### PR TITLE
SAC-30927:Exclude inaccessible streams from catalog during discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.2.0
+  * Inaccessible streams are excluded from the catalog during discovery instead of raising an error. [#24](https://github.com/singer-io/tap-monday/pull/24)
+
 ## 1.1.0
   * Fixed `SchemaMismatch` on `workspaces` stream — allow null array items in `workspaces`, `docs`, `folders`, `platform_api`, `reply`, and `teams` schemas. [#23](https://github.com/singer-io/tap-monday/pull/23)
   * Fixed set operator precedence bug in `_process_properties` and `KeyError` risk in `add_object_to_id`.

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="tap-monday",
-      version="1.1.0",
+      version="1.2.0",
       description="Singer.io tap for extracting data from Monday API",
       author="Stitch",
       url="http://singer.io",

--- a/tap_monday/__init__.py
+++ b/tap_monday/__init__.py
@@ -9,12 +9,12 @@ LOGGER = singer.get_logger()
 
 REQUIRED_CONFIG_KEYS = ['api_token', 'start_date', 'user_agent']
 
-def do_discover():
+def do_discover(client):
     """
     Discover and emit the catalog to stdout
     """
     LOGGER.info("Starting discover")
-    catalog = discover()
+    catalog = discover(client)
     json.dump(catalog.to_dict(), sys.stdout, indent=2)
     LOGGER.info("Finished discover")
 
@@ -31,8 +31,7 @@ def main():
 
     with Client(parsed_args.config) as client:
         if parsed_args.discover:
-            client.check_access()
-            do_discover()
+            do_discover(client)
         elif parsed_args.catalog:
             sync(
                 client=client,

--- a/tap_monday/client.py
+++ b/tap_monday/client.py
@@ -1,17 +1,18 @@
 from typing import Any, Dict, Mapping, Optional, Tuple
 import json
-import time
 
 import backoff
 import requests
 from requests import session
 from requests.exceptions import Timeout, ConnectionError, ChunkedEncodingError
+
 from singer import get_logger, metrics
 
 from tap_monday.exceptions import (
     ERROR_CODE_EXCEPTION_MAPPING,
     MondayError,
     MondayCursorExpiredError,
+    MondayForbiddenError,
     MondayRateLimitError,
     MondayInternalServerError,
     MondayServiceUnavailableError)
@@ -60,19 +61,29 @@ def raise_for_error(response: requests.Response) -> None:
                     response.status_code, {}).get("message", "Unknown Error")))
         exc = ERROR_CODE_EXCEPTION_MAPPING.get(
             response.status_code, {}).get("raise_exception", MondayError)
+        # Monday returns HTTP 200 for GraphQL-level errors. Map known extension
+        # codes to the appropriate exception so callers can handle them.
+        if response.status_code == 200 and response_json.get("errors"):
+            error_code = response_json["errors"][0].get("extensions", {}).get("code", "")
+            _GRAPHQL_ERROR_CODE_MAPPING = {
+                "UserUnauthorizedException": MondayForbiddenError,
+                "INTERNAL_SERVER_ERROR": MondayInternalServerError,
+            }
+            exc = _GRAPHQL_ERROR_CODE_MAPPING.get(error_code, exc)
         raise exc(message, response) from None
 
-def wait_if_retry_after(details):
-    """Backoff handler that checks for a 'retry_after' attribute in the exception
-    and sleeps for the specified duration to respect API rate limits.
+def get_retry_after(exception_info):
+    """Returns the retry_after value from RateLimitError exception.
+    This is used by backoff.runtime to determine wait time.
     """
-    exc = details.get('exception')
-    if exc is None:
-        # Fallback: backoff library may pass exception in args[0] depending on execution context
-        args = details.get('args') or ()
-        exc = args[0] if args else None
-    if exc and hasattr(exc, 'retry_after') and exc.retry_after is not None:
-        time.sleep(exc.retry_after)  # Force exact wait
+    exception = exception_info.get('exception') if isinstance(exception_info, dict) else exception_info
+
+    if exception and isinstance(exception, MondayRateLimitError):
+        retry_after = exception.retry_after or 60
+        LOGGER.info(f"Rate limited. Waiting {retry_after} seconds...")
+        return retry_after
+
+    return 60  # Default fallback
 
 class Client:
     """
@@ -146,19 +157,50 @@ class Client:
         headers, params = self.authenticate(headers, params)
         return self.__make_request(method, endpoint, headers=headers, params=params, data=body, timeout=self.request_timeout)
 
+    def probe_request(
+        self,
+        method: str,
+        endpoint: str,
+        params: Optional[Dict[str, Any]] = None,
+        headers: Optional[Dict[str, Any]] = None,
+        body: Optional[Dict[str, Any]] = None,
+    ) -> Any:
+        """Single-shot request with no backoff or retry — intended for access
+        probes during discovery where retrying is not appropriate."""
+        params = params or {}
+        headers = headers or {}
+        body = body or {}
+        headers, params = self.authenticate(headers, params)
+        response = self._session.request(
+            method.upper(), endpoint,
+            headers=headers, params=params, data=body,
+            timeout=self.request_timeout,
+        )
+        raise_for_error(response)
+        return response.json()
+
     @backoff.on_exception(
-        wait_gen=lambda: backoff.expo(factor=2),
-        on_backoff=wait_if_retry_after,
+        wait_gen=backoff.expo,
         exception=(
             ConnectionResetError,
             ConnectionError,
             ChunkedEncodingError,
             Timeout,
-            MondayRateLimitError,
             MondayInternalServerError,
-            MondayServiceUnavailableError
+            MondayServiceUnavailableError,
         ),
-        max_tries=5
+        max_tries=5,
+        factor=2,
+        giveup=lambda e: isinstance(e, MondayRateLimitError),
+    )
+    @backoff.on_exception(
+        backoff.runtime,
+        exception=(
+            MondayRateLimitError,
+        ),
+        max_tries=5,
+        value=get_retry_after,
+        jitter=None,
     )
     def __make_request(self, method: str, endpoint: str, **kwargs) -> Optional[Mapping[Any, Any]]:
         """

--- a/tap_monday/client.py
+++ b/tap_monday/client.py
@@ -13,6 +13,7 @@ from tap_monday.exceptions import (
     MondayError,
     MondayCursorExpiredError,
     MondayForbiddenError,
+    MondayGraphQLInternalError,
     MondayRateLimitError,
     MondayInternalServerError,
     MondayServiceUnavailableError)
@@ -67,7 +68,7 @@ def raise_for_error(response: requests.Response) -> None:
             error_code = response_json["errors"][0].get("extensions", {}).get("code", "")
             _GRAPHQL_ERROR_CODE_MAPPING = {
                 "UserUnauthorizedException": MondayForbiddenError,
-                "INTERNAL_SERVER_ERROR": MondayInternalServerError,
+                "INTERNAL_SERVER_ERROR": MondayGraphQLInternalError,
             }
             exc = _GRAPHQL_ERROR_CODE_MAPPING.get(error_code, exc)
         raise exc(message, response) from None
@@ -80,7 +81,7 @@ def get_retry_after(exception_info):
 
     if exception and isinstance(exception, MondayRateLimitError):
         retry_after = exception.retry_after or 60
-        LOGGER.info(f"Rate limited. Waiting {retry_after} seconds...")
+        LOGGER.info("Rate limited. Waiting %s seconds...", retry_after)
         return retry_after
 
     return 60  # Default fallback
@@ -163,7 +164,7 @@ class Client:
         endpoint: str,
         params: Optional[Dict[str, Any]] = None,
         headers: Optional[Dict[str, Any]] = None,
-        body: Optional[Dict[str, Any]] = None,
+        body: Optional[Any] = None,
     ) -> Any:
         """Single-shot request with no backoff or retry — intended for access
         probes during discovery where retrying is not appropriate."""

--- a/tap_monday/client.py
+++ b/tap_monday/client.py
@@ -191,7 +191,6 @@ class Client:
         ),
         max_tries=5,
         factor=2,
-        giveup=lambda e: isinstance(e, MondayRateLimitError),
     )
     @backoff.on_exception(
         backoff.runtime,

--- a/tap_monday/discover.py
+++ b/tap_monday/discover.py
@@ -48,7 +48,9 @@ def _apply_access_checks(client, schemas: dict, field_metadata: dict) -> None:
     for stream_name in list(schemas.keys()):
         stream_cls = STREAMS.get(stream_name)
         if stream_cls:
-            stream_cls(client=client).prune_inaccessible_fields(schemas[stream_name])
+            stream_cls(client=client).prune_inaccessible_fields(
+                schemas[stream_name], field_metadata[stream_name]
+            )
 
     if inaccessible_streams:
         total_parent_streams = len([s for s in STREAMS.values() if not s.parent])

--- a/tap_monday/discover.py
+++ b/tap_monday/discover.py
@@ -52,13 +52,12 @@ def _apply_access_checks(client, schemas: dict, field_metadata: dict) -> None:
                 schemas[stream_name], field_metadata[stream_name]
             )
 
+    if not schemas:
+        raise MondayForbiddenError(
+            "HTTP-error-code: 403, Error: The account credentials supplied do not have 'read' access to any "
+            "of the streams supported by the tap. Data collection cannot be initiated due to lack of permissions."
+        )
     if inaccessible_streams:
-        total_parent_streams = len([s for s in STREAMS.values() if not s.parent])
-        if len(inaccessible_streams) == total_parent_streams:
-            raise MondayForbiddenError(
-                "HTTP-error-code: 403, Error: The account credentials supplied do not have 'read' access to any "
-                "of the streams supported by the tap. Data collection cannot be initiated due to lack of permissions."
-            )
         LOGGER.warning(
             "The account credentials supplied do not have 'read' access to the following stream(s): %s. "
             "These streams have been excluded from the catalog.",

--- a/tap_monday/discover.py
+++ b/tap_monday/discover.py
@@ -3,7 +3,7 @@ from singer import metadata
 from singer.catalog import Catalog, CatalogEntry, Schema
 from tap_monday.schema import get_schemas
 from tap_monday.streams import STREAMS
-from tap_monday.exceptions import MondayForbiddenError, MondayInternalServerError
+from tap_monday.exceptions import MondayForbiddenError
 
 LOGGER = singer.get_logger()
 
@@ -27,19 +27,15 @@ def _apply_access_checks(client, schemas: dict, field_metadata: dict) -> None:
     """
     Probe each stream for read access and remove inaccessible streams
     (and their children) from schemas and field_metadata in place.
-    Note: check_access() always returns None for child streams, so this loop
+    Note: check_access() always returns True for child streams, so this loop
     effectively identifies only inaccessible parent streams by design.
     Child stream removal is handled separately by _prune_inaccessible_children().
     Raises MondayForbiddenError if no parent streams are accessible.
     """
-    # Map stream_name -> the exception returned by check_access (None means accessible).
-    access_results = {
-        stream_name: stream_obj(client=client).check_access()
-        for stream_name, stream_obj in STREAMS.items()
-        if stream_name in schemas
-    }
     inaccessible_streams = [
-        name for name, exc in access_results.items() if exc is not None
+        stream_name
+        for stream_name, stream_obj in STREAMS.items()
+        if stream_name in schemas and not stream_obj(client=client).check_access()
     ]
 
     for stream_name in inaccessible_streams:
@@ -48,18 +44,15 @@ def _apply_access_checks(client, schemas: dict, field_metadata: dict) -> None:
 
     _prune_inaccessible_children(schemas, field_metadata)
 
+    # For accessible streams, prune any plan-gated fields from their catalog schema.
+    for stream_name in list(schemas.keys()):
+        stream_cls = STREAMS.get(stream_name)
+        if stream_cls:
+            stream_cls(client=client).prune_inaccessible_fields(schemas[stream_name])
+
     if inaccessible_streams:
         total_parent_streams = len([s for s in STREAMS.values() if not s.parent])
         if len(inaccessible_streams) == total_parent_streams:
-            # Determine the dominant failure type to build an accurate message.
-            causes = [access_results[n] for n in inaccessible_streams]
-            has_500 = any(isinstance(c, MondayInternalServerError) for c in causes)
-            has_403 = any(isinstance(c, MondayForbiddenError) for c in causes)
-            if has_500 and not has_403:
-                raise MondayInternalServerError(
-                    "HTTP-error-code: 500, Error: All streams returned a server error during access checks. "
-                    "This may indicate a missing app installation or a platform-side issue."
-                )
             raise MondayForbiddenError(
                 "HTTP-error-code: 403, Error: The account credentials supplied do not have 'read' access to any "
                 "of the streams supported by the tap. Data collection cannot be initiated due to lack of permissions."

--- a/tap_monday/discover.py
+++ b/tap_monday/discover.py
@@ -3,7 +3,7 @@ from singer import metadata
 from singer.catalog import Catalog, CatalogEntry, Schema
 from tap_monday.schema import get_schemas
 from tap_monday.streams import STREAMS
-from tap_monday.exceptions import MondayForbiddenError
+from tap_monday.exceptions import MondayForbiddenError, MondayInternalServerError
 
 LOGGER = singer.get_logger()
 
@@ -27,16 +27,19 @@ def _apply_access_checks(client, schemas: dict, field_metadata: dict) -> None:
     """
     Probe each stream for read access and remove inaccessible streams
     (and their children) from schemas and field_metadata in place.
-    Note: check_access() always returns True for child streams, so this loop
+    Note: check_access() always returns None for child streams, so this loop
     effectively identifies only inaccessible parent streams by design.
     Child stream removal is handled separately by _prune_inaccessible_children().
     Raises MondayForbiddenError if no parent streams are accessible.
     """
-    inaccessible_streams = [
-        stream_name
+    # Map stream_name -> the exception returned by check_access (None means accessible).
+    access_results = {
+        stream_name: stream_obj(client=client).check_access()
         for stream_name, stream_obj in STREAMS.items()
         if stream_name in schemas
-        and not stream_obj(client=client).check_access()
+    }
+    inaccessible_streams = [
+        name for name, exc in access_results.items() if exc is not None
     ]
 
     for stream_name in inaccessible_streams:
@@ -48,6 +51,15 @@ def _apply_access_checks(client, schemas: dict, field_metadata: dict) -> None:
     if inaccessible_streams:
         total_parent_streams = len([s for s in STREAMS.values() if not s.parent])
         if len(inaccessible_streams) == total_parent_streams:
+            # Determine the dominant failure type to build an accurate message.
+            causes = [access_results[n] for n in inaccessible_streams]
+            has_500 = any(isinstance(c, MondayInternalServerError) for c in causes)
+            has_403 = any(isinstance(c, MondayForbiddenError) for c in causes)
+            if has_500 and not has_403:
+                raise MondayInternalServerError(
+                    "HTTP-error-code: 500, Error: All streams returned a server error during access checks. "
+                    "This may indicate a missing app installation or a platform-side issue."
+                )
             raise MondayForbiddenError(
                 "HTTP-error-code: 403, Error: The account credentials supplied do not have 'read' access to any "
                 "of the streams supported by the tap. Data collection cannot be initiated due to lack of permissions."

--- a/tap_monday/discover.py
+++ b/tap_monday/discover.py
@@ -2,15 +2,71 @@ import singer
 from singer import metadata
 from singer.catalog import Catalog, CatalogEntry, Schema
 from tap_monday.schema import get_schemas
+from tap_monday.streams import STREAMS
+from tap_monday.exceptions import MondayForbiddenError
 
 LOGGER = singer.get_logger()
 
 
-def discover() -> Catalog:
+def _prune_inaccessible_children(schemas: dict, field_metadata: dict) -> None:
+    """
+    Remove child streams from the catalog whose parent stream was excluded.
+    Mutates schemas and field_metadata in place.
+    """
+    for name, stream_cls in list(STREAMS.items()):
+        if name in schemas and stream_cls.parent and stream_cls.parent not in schemas:
+            LOGGER.warning(
+                "Stream '%s' excluded from catalog because its parent stream '%s' is not accessible.",
+                name, stream_cls.parent,
+            )
+            schemas.pop(name)
+            field_metadata.pop(name)
+
+
+def _apply_access_checks(client, schemas: dict, field_metadata: dict) -> None:
+    """
+    Probe each stream for read access and remove inaccessible streams
+    (and their children) from schemas and field_metadata in place.
+    Note: check_access() always returns True for child streams, so this loop
+    effectively identifies only inaccessible parent streams by design.
+    Child stream removal is handled separately by _prune_inaccessible_children().
+    Raises MondayForbiddenError if no parent streams are accessible.
+    """
+    inaccessible_streams = [
+        stream_name
+        for stream_name, stream_obj in STREAMS.items()
+        if stream_name in schemas
+        and not stream_obj(client=client).check_access()
+    ]
+
+    for stream_name in inaccessible_streams:
+        schemas.pop(stream_name, None)
+        field_metadata.pop(stream_name, None)
+
+    _prune_inaccessible_children(schemas, field_metadata)
+
+    if inaccessible_streams:
+        total_parent_streams = len([s for s in STREAMS.values() if not s.parent])
+        if len(inaccessible_streams) == total_parent_streams:
+            raise MondayForbiddenError(
+                "HTTP-error-code: 403, Error: The account credentials supplied do not have 'read' access to any "
+                "of the streams supported by the tap. Data collection cannot be initiated due to lack of permissions."
+            )
+        LOGGER.warning(
+            "The account credentials supplied do not have 'read' access to the following stream(s): %s. "
+            "These streams have been excluded from the catalog.",
+            ", ".join(inaccessible_streams),
+        )
+
+
+def discover(client) -> Catalog:
     """
     Run the discovery mode, prepare the catalog file and return the catalog.
+    Access to each stream is verified using the provided client and streams
+    the credentials cannot read are excluded from the returned catalog.
     """
     schemas, field_metadata = get_schemas()
+    _apply_access_checks(client, schemas, field_metadata)
     catalog = Catalog([])
 
     for stream_name, schema_dict in schemas.items():

--- a/tap_monday/exceptions.py
+++ b/tap_monday/exceptions.py
@@ -72,6 +72,15 @@ class MondayInternalServerError(MondayBackoffError):
     """class representing 500 status code."""
     pass
 
+
+class MondayGraphQLInternalError(MondayError):
+    """Raised when the Monday.com GraphQL API returns an INTERNAL_SERVER_ERROR extension code
+    on an otherwise HTTP-200 response. This is distinct from MondayInternalServerError
+    (HTTP 500) and typically indicates a plan restriction or unsupported feature
+    rather than a transient server failure, so it is not retried by backoff.
+    """
+    pass
+
 class MondayNotImplementedError(MondayBackoffError):
     """class representing 501 status code."""
     pass

--- a/tap_monday/streams/abstracts.py
+++ b/tap_monday/streams/abstracts.py
@@ -11,7 +11,7 @@ from singer import (
     write_schema,
     metadata
 )
-from tap_monday.exceptions import MondayForbiddenError, MondayInternalServerError
+from tap_monday.exceptions import MondayForbiddenError, MondayGraphQLInternalError
 
 LOGGER = get_logger()
 
@@ -81,42 +81,50 @@ class BaseStream(ABC):
     def key_properties(self) -> Tuple[str, str]:
         """List of key properties for stream."""
 
-    def check_access(self):
+    def check_access(self) -> bool:
         """
         Verify that the API credentials have read access to this stream.
-        Returns None if accessible, or the caught exception if not.
-        Child streams always return None (access is governed by the parent check).
+        Returns True if accessible, False if not.
+        Child streams always return True (access is governed by the parent check).
         """
         if self.parent:
-            return None
+            return True
 
         root_bare = (self.root_field or "").split("(")[0].strip()
         if not root_bare:
-            return None
+            return True
 
         url = self.get_url_endpoint()
         self.update_params()
         body = json.dumps({"query": f"query {{ {root_bare} {{ {self.check_access_fields} }} }}"})
         try:
             self.client.probe_request(self.http_method, url, self.params, self.headers, body=body)
-            return None
-        except MondayForbiddenError as e:
+            return True
+        except MondayForbiddenError:
             LOGGER.warning(
                 "Stream '%s' does not have read permission (403), excluding from catalog.",
                 self.__class__.__name__,
             )
-            return e
-        except MondayInternalServerError as e:
+            return False
+        except MondayGraphQLInternalError:
             LOGGER.warning(
-                "Stream '%s' returned a server error (500) during access check — "
+                "Stream '%s' returned a server error during access check — "
                 "this likely indicates a missing app installation or insufficient permissions. "
                 "Excluding from catalog.",
                 self.__class__.__name__,
             )
-            return e
+            return False
 
     def is_selected(self):
         return metadata.get(self.metadata, (), "selected")
+
+    def prune_inaccessible_fields(self, schema: dict) -> None:
+        """Probe individual fields that may not be accessible on all plans and
+        remove them from *schema* (mutates in place) if the API returns an error.
+        Override in subclasses that have plan-gated fields.
+        Default implementation is a no-op.
+        """
+        pass
 
     @abstractmethod
     def sync(

--- a/tap_monday/streams/abstracts.py
+++ b/tap_monday/streams/abstracts.py
@@ -11,6 +11,7 @@ from singer import (
     write_schema,
     metadata
 )
+from tap_monday.exceptions import MondayForbiddenError, MondayInternalServerError
 
 LOGGER = get_logger()
 
@@ -38,6 +39,7 @@ class BaseStream(ABC):
     parent_bookmark_key = ""
     graphql_query_key = "query"
     root_field = None
+    check_access_fields = "__typename"
     extra_fields = {}
     excluded_fields = []
     pagination_supported = False
@@ -46,12 +48,13 @@ class BaseStream(ABC):
     def __init__(self, client=None, catalog=None) -> None:
         self.client = client
         self.catalog = catalog
-        self.schema = catalog.schema.to_dict()
-        self.metadata = metadata.to_map(catalog.metadata)
+        self.schema = catalog.schema.to_dict() if catalog else {}
+        self.metadata = metadata.to_map(catalog.metadata) if catalog else {}
         self.child_to_sync = []
         self.params = {}
         self.data_payload = {}
         self.http_method = "POST"
+        self.page_size = self.client.config.get("page_size", self.page_size) if client else self.page_size
 
     @property
     @abstractmethod
@@ -77,6 +80,40 @@ class BaseStream(ABC):
     @abstractmethod
     def key_properties(self) -> Tuple[str, str]:
         """List of key properties for stream."""
+
+    def check_access(self) -> bool:
+        """
+        Verify that the API credentials have read access to this stream.
+        Returns True if accessible, False if a 403 Forbidden error is raised.
+        Child streams always return True (access is governed by the parent check).
+        """
+        if self.parent:
+            return True
+
+        root_bare = (self.root_field or "").split("(")[0].strip()
+        if not root_bare:
+            return True
+
+        url = self.get_url_endpoint()
+        self.update_params()
+        body = json.dumps({"query": f"query {{ {root_bare} {{ {self.check_access_fields} }} }}"})
+        try:
+            self.client.probe_request(self.http_method, url, self.params, self.headers, body=body)
+            return True
+        except MondayForbiddenError:
+            LOGGER.warning(
+                "Stream '%s' does not have read permission (403), excluding from catalog.",
+                self.__class__.__name__,
+            )
+            return False
+        except MondayInternalServerError:
+            LOGGER.warning(
+                "Stream '%s' returned a server error (500) during access check — "
+                "this likely indicates a missing app installation or insufficient permissions. "
+                "Excluding from catalog.",
+                self.__class__.__name__,
+            )
+            return False
 
     def is_selected(self):
         return metadata.get(self.metadata, (), "selected")

--- a/tap_monday/streams/abstracts.py
+++ b/tap_monday/streams/abstracts.py
@@ -118,9 +118,10 @@ class BaseStream(ABC):
     def is_selected(self):
         return metadata.get(self.metadata, (), "selected")
 
-    def prune_inaccessible_fields(self, schema: dict) -> None:
+    def prune_inaccessible_fields(self, schema: dict, field_metadata: list) -> None:
         """Probe individual fields that may not be accessible on all plans and
         remove them from *schema* (mutates in place) if the API returns an error.
+        Also removes the corresponding metadata entries from *field_metadata*.
         Override in subclasses that have plan-gated fields.
         Default implementation is a no-op.
         """

--- a/tap_monday/streams/abstracts.py
+++ b/tap_monday/streams/abstracts.py
@@ -81,39 +81,39 @@ class BaseStream(ABC):
     def key_properties(self) -> Tuple[str, str]:
         """List of key properties for stream."""
 
-    def check_access(self) -> bool:
+    def check_access(self):
         """
         Verify that the API credentials have read access to this stream.
-        Returns True if accessible, False if a 403 Forbidden error is raised.
-        Child streams always return True (access is governed by the parent check).
+        Returns None if accessible, or the caught exception if not.
+        Child streams always return None (access is governed by the parent check).
         """
         if self.parent:
-            return True
+            return None
 
         root_bare = (self.root_field or "").split("(")[0].strip()
         if not root_bare:
-            return True
+            return None
 
         url = self.get_url_endpoint()
         self.update_params()
         body = json.dumps({"query": f"query {{ {root_bare} {{ {self.check_access_fields} }} }}"})
         try:
             self.client.probe_request(self.http_method, url, self.params, self.headers, body=body)
-            return True
-        except MondayForbiddenError:
+            return None
+        except MondayForbiddenError as e:
             LOGGER.warning(
                 "Stream '%s' does not have read permission (403), excluding from catalog.",
                 self.__class__.__name__,
             )
-            return False
-        except MondayInternalServerError:
+            return e
+        except MondayInternalServerError as e:
             LOGGER.warning(
                 "Stream '%s' returned a server error (500) during access check — "
                 "this likely indicates a missing app installation or insufficient permissions. "
                 "Excluding from catalog.",
                 self.__class__.__name__,
             )
-            return False
+            return e
 
     def is_selected(self):
         return metadata.get(self.metadata, (), "selected")

--- a/tap_monday/streams/platform_api.py
+++ b/tap_monday/streams/platform_api.py
@@ -13,6 +13,7 @@ class PlatformApi(IncrementalStream):
     bookmark_value = None
     data_key = "data.platform_api"
     root_field = "platform_api"
+    check_access_fields = "daily_limit { total }"
     excluded_fields = ["last_updated"]
     extra_fields = {
         "daily_analytics.last_updated": []

--- a/tap_monday/streams/platform_api.py
+++ b/tap_monday/streams/platform_api.py
@@ -1,6 +1,7 @@
 from typing import Dict, Any
 from singer import get_logger
 from tap_monday.streams.abstracts import IncrementalStream
+from tap_monday.exceptions import MondayForbiddenError, MondayGraphQLInternalError
 
 LOGGER = get_logger()
 
@@ -13,11 +14,34 @@ class PlatformApi(IncrementalStream):
     bookmark_value = None
     data_key = "data.platform_api"
     root_field = "platform_api"
-    check_access_fields = "daily_limit { total }"
     excluded_fields = ["last_updated"]
     extra_fields = {
         "daily_analytics.last_updated": []
     }
+
+    def check_access(self):
+        """platform_api is always present; only individual fields are plan-gated.
+        Field-level access is handled by prune_inaccessible_fields(), so skip
+        the stream-level probe here."""
+        return True
+
+    def prune_inaccessible_fields(self, schema: dict) -> None:
+        """Probe whether daily_limit is accessible for this account's Monday plan.
+        If the field is not available (403 or 500), remove it from the catalog
+        schema dict and log a warning so sync can continue without it.
+        """
+        import json as _json
+        url = self.get_url_endpoint()
+        self.update_params()
+        body = _json.dumps({"query": "query { platform_api { daily_limit { total } } }"})
+        try:
+            self.client.probe_request(self.http_method, url, self.params, self.headers, body=body)
+        except (MondayForbiddenError, MondayGraphQLInternalError):
+            LOGGER.warning(
+                "Stream 'platform_api': field 'daily_limit' is not supported for this "
+                "Monday plan — removing it from the catalog. Sync will continue without it."
+            )
+            schema.get("properties", {}).pop("daily_limit", None)
 
     def get_bookmark(self, state: Dict, key: Any = None) -> int:
         """

--- a/tap_monday/streams/platform_api.py
+++ b/tap_monday/streams/platform_api.py
@@ -25,10 +25,11 @@ class PlatformApi(IncrementalStream):
         the stream-level probe here."""
         return True
 
-    def prune_inaccessible_fields(self, schema: dict) -> None:
+    def prune_inaccessible_fields(self, schema: dict, field_metadata: list) -> None:
         """Probe whether daily_limit is accessible for this account's Monday plan.
-        If the field is not available (403 or 500), remove it from the catalog
-        schema dict and log a warning so sync can continue without it.
+        If the field is not available (MondayForbiddenError or MondayGraphQLInternalError),
+        remove it from the catalog schema and its metadata entry, and log a warning
+        so sync can continue without it.
         """
         import json as _json
         url = self.get_url_endpoint()
@@ -39,9 +40,16 @@ class PlatformApi(IncrementalStream):
         except (MondayForbiddenError, MondayGraphQLInternalError):
             LOGGER.warning(
                 "Stream 'platform_api': field 'daily_limit' is not supported for this "
-                "Monday plan — removing it from the catalog. Sync will continue without it."
+                "Monday plan removing it from the catalog. Sync will continue without it."
             )
             schema.get("properties", {}).pop("daily_limit", None)
+            field_metadata[:] = [
+                entry for entry in field_metadata
+                if entry.get("breadcrumb") not in (
+                    ["properties", "daily_limit"],
+                    ("properties", "daily_limit"),
+                )
+            ]
 
     def get_bookmark(self, state: Dict, key: Any = None) -> int:
         """

--- a/tests/base.py
+++ b/tests/base.py
@@ -18,6 +18,7 @@ class MondayBaseTest(BaseCase):
     in tap-tester tests. Shared tap-specific methods (as needed).
     """
     start_date = "2019-01-01T00:00:00Z"
+    IS_FORBIDDEN_STREAM = "is-forbidden-stream"
 
     @staticmethod
     def tap_name():
@@ -122,7 +123,8 @@ class MondayBaseTest(BaseCase):
                 cls.REPLICATION_METHOD: cls.INCREMENTAL,
                 cls.REPLICATION_KEYS: { "last_updated" },
                 cls.RESPECTS_START_DATE: True,
-                cls.API_LIMIT: 1
+                cls.API_LIMIT: 1,
+                cls.IS_FORBIDDEN_STREAM: True
             },
             "reply": {
                 cls.PRIMARY_KEYS: { "id", "update_id" },
@@ -187,3 +189,11 @@ class MondayBaseTest(BaseCase):
             "start_date": self.start_date
         }
         return return_value
+
+    def expected_stream_names(self):
+        """The expected stream names and exclude forbidden streams."""
+        return {
+            stream_name
+            for stream_name, metadata in self.expected_metadata().items()
+            if not metadata.get(self.IS_FORBIDDEN_STREAM, False)
+        }

--- a/tests/base.py
+++ b/tests/base.py
@@ -191,7 +191,7 @@ class MondayBaseTest(BaseCase):
         return return_value
 
     def expected_stream_names(self):
-        """The expected stream names and exclude forbidden streams."""
+        """The expected stream names and excludes forbidden streams."""
         return {
             stream_name
             for stream_name, metadata in self.expected_metadata().items()

--- a/tests/base.py
+++ b/tests/base.py
@@ -123,8 +123,7 @@ class MondayBaseTest(BaseCase):
                 cls.REPLICATION_METHOD: cls.INCREMENTAL,
                 cls.REPLICATION_KEYS: { "last_updated" },
                 cls.RESPECTS_START_DATE: True,
-                cls.API_LIMIT: 1,
-                cls.IS_FORBIDDEN_STREAM: True
+                cls.API_LIMIT: 1
             },
             "reply": {
                 cls.PRIMARY_KEYS: { "id", "update_id" },

--- a/tests/test_bookmark.py
+++ b/tests/test_bookmark.py
@@ -9,7 +9,6 @@ class MondayBookMarkTest(BookmarkTest, MondayBaseTest):
     initial_bookmarks = {
         "bookmarks": {
             "boards": { "updated_at" : "2020-01-01T00:00:00Z"},
-            "board_activity_logs": { "created_at" : "2020-01-01T00:00:00Z"},
             "board_items": { "updated_at" : "2020-01-01T00:00:00Z"},
             "updates": { "updated_at" : "2020-01-01T00:00:00Z"},
             "reply": { "updated_at" : "2020-01-01T00:00:00Z"},
@@ -35,7 +34,8 @@ class MondayBookMarkTest(BookmarkTest, MondayBaseTest):
             "account",
             "assets",
             "users",
-            "platform_api"
+            "platform_api",
+            "board_activity_logs"
         }
         return self.expected_stream_names().difference(streams_to_exclude)
 

--- a/tests/test_interrupted_sync.py
+++ b/tests/test_interrupted_sync.py
@@ -3,7 +3,7 @@ from base import MondayBaseTest
 from tap_tester.base_suite_tests.interrupted_sync_test import InterruptedSyncTest
 
 
-class MondayInterruptedSyncTest(MondayBaseTest):
+class MondayInterruptedSyncTest(InterruptedSyncTest, MondayBaseTest):
     """Test tap sets a bookmark and respects it for the next sync of a
     stream."""
 
@@ -12,17 +12,33 @@ class MondayInterruptedSyncTest(MondayBaseTest):
         return "tap_tester_monday_interrupted_sync_test"
 
     def streams_to_test(self):
-        return self.expected_stream_names()
+        streams_to_exclude = {
+            "audit_event_catalogue",
+            "column_values",
+            "teams",
+            "workspaces",
+            "tags",
+            "folders",
+            "board_views",
+            "board_groups",
+            "board_columns",
+            "docs",
+            "account",
+            "assets",
+            "users",
+            "platform_api",
+            "board_activity_logs",
+            "account"
+        }
+        return self.expected_stream_names().difference(streams_to_exclude)
 
 
     def manipulate_state(self):
         return {
-            "currently_syncing": "prospects",
+            "currently_syncing": "boards",
             "bookmarks": {
                 "boards": { "updated_at" : "2020-01-01T00:00:00Z"},
-                "board_activity_logs": { "created_at" : "2020-01-01T00:00:00Z"},
                 "board_items": { "updated_at" : "2020-01-01T00:00:00Z"},
-                "platform_api": { "last_updated" : "2020-01-01T00:00:00Z"},
                 "reply": { "updated_at" : "2020-01-01T00:00:00Z"},
                 "updates": { "updated_at" : "2020-01-01T00:00:00Z"}
             }

--- a/tests/test_start_date.py
+++ b/tests/test_start_date.py
@@ -26,6 +26,7 @@ class MondayStartDateTest(StartDateTest, MondayBaseTest):
             # platform_api returns only 1 system-level record (API usage analytics),
             # insufficient for start date testing
             "platform_api",
+            "board_activity_logs",
             "tags",
             "teams",
             # updates stream has all records with updated_at >= start_date_2,

--- a/tests/unittests/test_client.py
+++ b/tests/unittests/test_client.py
@@ -3,7 +3,7 @@ from parameterized import parameterized
 from unittest.mock import patch, MagicMock
 from requests import Timeout, ConnectionError
 
-from tap_monday.client import Client, raise_for_error, wait_if_retry_after
+from tap_monday.client import Client, raise_for_error, get_retry_after
 from tap_monday.exceptions import (
     ERROR_CODE_EXCEPTION_MAPPING,
     MondayError,
@@ -167,98 +167,38 @@ class TestCheckAccess(unittest.TestCase):
                 self.client.check_access()
 
 
-class TestWaitIfRetryAfter(unittest.TestCase):
-    """Test the wait_if_retry_after backoff handler function."""
+class TestGetRetryAfter(unittest.TestCase):
+    """Test the get_retry_after backoff value function."""
 
-    @patch('time.sleep')
-    def test_wait_if_retry_after_with_retry_after_attribute(self, mock_sleep):
-        """Test that the handler sleeps for the exact duration from retry_after."""
-        # Create a mock exception with retry_after attribute
-        mock_exception = MagicMock()
-        mock_exception.retry_after = 5
-
-        details = {'exception': mock_exception}
-        wait_if_retry_after(details)
-
-        # Verify it slept for the exact duration
-        mock_sleep.assert_called_once_with(5)
-
-    @patch('time.sleep')
-    def test_wait_if_retry_after_with_none_retry_after(self, mock_sleep):
-        """Test that the handler does not sleep when retry_after is None."""
-        mock_exception = MagicMock()
-        mock_exception.retry_after = None
-
-        details = {'exception': mock_exception}
-        wait_if_retry_after(details)
-
-        # Verify it did not sleep
-        mock_sleep.assert_not_called()
-
-    @patch('time.sleep')
-    def test_wait_if_retry_after_without_retry_after_attribute(self, mock_sleep):
-        """Test that the handler does not sleep when exception has no retry_after attribute."""
-        mock_exception = MagicMock(spec=[])
-
-        details = {'exception': mock_exception}
-        wait_if_retry_after(details)
-
-        # Verify it did not sleep
-        mock_sleep.assert_not_called()
-
-    @patch('time.sleep')
-    def test_wait_if_retry_after_with_exception_in_args(self, mock_sleep):
-        """Test that the handler finds the exception in args[0] when not in 'exception' key."""
-        mock_exception = MagicMock()
-        mock_exception.retry_after = 10
-
-        details = {'args': (mock_exception,)}
-        wait_if_retry_after(details)
-
-        # Verify it slept for the exact duration
-        mock_sleep.assert_called_once_with(10)
-
-    @patch('time.sleep')
-    def test_wait_if_retry_after_with_no_exception(self, mock_sleep):
-        """Test that the handler does not sleep when no exception is present."""
-        details = {}
-        wait_if_retry_after(details)
-
-        # Verify it did not sleep
-        mock_sleep.assert_not_called()
-
-    @patch('time.sleep')
-    def test_wait_if_retry_after_with_real_rate_limit_error(self, mock_sleep):
-        """Test with an actual MondayRateLimitError instance."""
-        # Create a mock response with retry_in_seconds
+    def test_rate_limit_error_with_retry_after(self):
+        """Returns retry_after seconds from a MondayRateLimitError."""
         mock_response = MockResponse(
             status_code=429,
-            json_data={
-                "errors": [{
-                    "message": "Rate limit exceeded",
-                    "extensions": {
-                        "code": "RATE_LIMIT",
-                        "retry_in_seconds": 15
-                    }
-                }]
-            }
+            json_data={"errors": [{"message": "Rate limit", "extensions": {"code": "RATE_LIMIT", "retry_in_seconds": 15}}]}
         )
-
-        # Create actual exception with the response
         exc = MondayRateLimitError(response=mock_response)
+        self.assertEqual(get_retry_after({'exception': exc}), 15)
 
-        details = {'exception': exc}
-        wait_if_retry_after(details)
+    def test_rate_limit_error_with_none_retry_after(self):
+        """Returns 60 (default) when retry_after is None on a MondayRateLimitError."""
+        mock_response = MockResponse(status_code=429, json_data={"errors": [{"message": "Rate limit"}]})
+        exc = MondayRateLimitError(response=mock_response)
+        self.assertEqual(get_retry_after({'exception': exc}), 60)
 
-        # Verify it slept for the exact duration from the API response
-        mock_sleep.assert_called_once_with(15)
+    def test_non_rate_limit_exception_returns_default(self):
+        """Returns 60 when the exception is not a MondayRateLimitError."""
+        self.assertEqual(get_retry_after({'exception': Exception("other")}), 60)
 
-    @patch('time.sleep')
-    def test_wait_if_retry_after_with_empty_args(self, mock_sleep):
-        """Test that the handler handles empty args gracefully."""
-        details = {'args': ()}
-        wait_if_retry_after(details)
+    def test_no_exception_returns_default(self):
+        """Returns 60 when no exception key is present."""
+        self.assertEqual(get_retry_after({}), 60)
 
-        # Verify it did not sleep
-        mock_sleep.assert_not_called()
+    def test_exception_passed_directly(self):
+        """Accepts the exception object directly (not wrapped in a dict)."""
+        mock_response = MockResponse(
+            status_code=429,
+            json_data={"errors": [{"message": "Rate limit", "extensions": {"code": "RATE_LIMIT", "retry_in_seconds": 30}}]}
+        )
+        exc = MondayRateLimitError(response=mock_response)
+        self.assertEqual(get_retry_after(exc), 30)
 

--- a/tests/unittests/test_discovery.py
+++ b/tests/unittests/test_discovery.py
@@ -27,7 +27,7 @@ from unittest.mock import MagicMock, patch
 from singer.catalog import Catalog
 
 from tap_monday.discover import discover, _apply_access_checks, _prune_inaccessible_children
-from tap_monday.exceptions import MondayForbiddenError
+from tap_monday.exceptions import MondayForbiddenError, MondayInternalServerError
 from tap_monday.schema import get_schemas, get_abs_path
 from tap_monday.streams import STREAMS
 
@@ -471,6 +471,30 @@ class TestApplyAccessChecks(unittest.TestCase):
             with self.assertRaises(MondayForbiddenError):
                 _apply_access_checks(client, schemas, field_metadata)
 
+    def test_all_parents_inaccessible_via_500_raises_internal_server_error(self):
+        """When all failures are 500s (not 403s), MondayInternalServerError must be raised."""
+        schemas, field_metadata = self._schemas_and_metadata()
+        client = _make_mock_client()
+
+        def _make_500_stream_cls(name, original_cls):
+            class _ServerError(original_cls):
+                def check_access(self):
+                    return MondayInternalServerError("500")
+            _ServerError.parent = original_cls.parent
+            _ServerError.children = original_cls.children
+            _ServerError.tap_stream_id = original_cls.tap_stream_id
+            _ServerError.__name__ = original_cls.__name__
+            return _ServerError
+
+        patched = {
+            name: _make_500_stream_cls(name, cls) if not cls.parent
+            else _make_accessible_stream_cls(name, cls)
+            for name, cls in STREAMS.items()
+        }
+        with patch("tap_monday.discover.STREAMS", patched):
+            with self.assertRaises(MondayInternalServerError):
+                _apply_access_checks(client, schemas, field_metadata)
+
     def test_discover_with_client_runs_access_checks(self):
         """discover(client) must call _apply_access_checks."""
         client = _make_mock_client()
@@ -545,7 +569,7 @@ class TestPruneInaccessibleChildren(unittest.TestCase):
 # ---------------------------------------------------------------------------
 
 class TestBaseStreamCheckAccess(unittest.TestCase):
-    """BaseStream.check_access() must return True/False based on API response."""
+    """BaseStream.check_access() must return None or an exception based on API response."""
 
     def _make_stream_instance(self, stream_name, forbidden=False):
         """Instantiate a stream with a mock client that either succeeds or raises 403."""
@@ -555,19 +579,24 @@ class TestBaseStreamCheckAccess(unittest.TestCase):
         stream_cls = STREAMS[stream_name]
         return stream_cls(client=client)
 
-    def test_accessible_stream_returns_true(self):
+    def test_accessible_stream_returns_none(self):
         stream = self._make_stream_instance("account", forbidden=False)
-        self.assertTrue(stream.check_access())
+        self.assertIsNone(stream.check_access())
 
-    def test_forbidden_stream_returns_false(self):
+    def test_forbidden_stream_returns_exception(self):
         stream = self._make_stream_instance("account", forbidden=True)
-        self.assertFalse(stream.check_access())
+        self.assertIsInstance(stream.check_access(), MondayForbiddenError)
 
-    def test_child_stream_always_returns_true(self):
-        """Child streams skip the HTTP probe and always return True."""
+    def test_internal_server_error_stream_returns_exception(self):
+        stream = self._make_stream_instance("account")
+        stream.client.probe_request.side_effect = MondayInternalServerError("500")
+        self.assertIsInstance(stream.check_access(), MondayInternalServerError)
+
+    def test_child_stream_always_returns_none(self):
+        """Child streams skip the HTTP probe and always return None."""
         # board_columns has parent="boards"
         child_stream = self._make_stream_instance("board_columns", forbidden=True)
-        self.assertTrue(child_stream.check_access())
+        self.assertIsNone(child_stream.check_access())
         # Even though probe_request would raise 403, it should never be called
         child_stream.client.probe_request.assert_not_called()
 
@@ -580,7 +609,7 @@ class TestBaseStreamCheckAccess(unittest.TestCase):
         stream = self._make_stream_instance("account", forbidden=True)
         with patch("tap_monday.streams.abstracts.LOGGER") as mock_logger:
             result = stream.check_access()
-            self.assertFalse(result)
+            self.assertIsInstance(result, MondayForbiddenError)
             mock_logger.warning.assert_called_once()
 
 
@@ -589,10 +618,10 @@ class TestBaseStreamCheckAccess(unittest.TestCase):
 # ---------------------------------------------------------------------------
 
 def _make_accessible_stream_cls(name, original_cls):
-    """Return a subclass of the original that overrides check_access to return True."""
+    """Return a subclass of the original that overrides check_access to return None (accessible)."""
     class _Accessible(original_cls):
         def check_access(self):
-            return True
+            return None
     _Accessible.parent = original_cls.parent
     _Accessible.children = original_cls.children
     _Accessible.tap_stream_id = original_cls.tap_stream_id
@@ -601,10 +630,10 @@ def _make_accessible_stream_cls(name, original_cls):
 
 
 def _make_forbidden_stream_cls(name, original_cls):
-    """Return a subclass of the original that overrides check_access to return False."""
+    """Return a subclass of the original that overrides check_access to return a MondayForbiddenError."""
     class _Forbidden(original_cls):
         def check_access(self):
-            return False
+            return MondayForbiddenError("403 Forbidden")
     _Forbidden.parent = original_cls.parent
     _Forbidden.children = original_cls.children
     _Forbidden.tap_stream_id = original_cls.tap_stream_id

--- a/tests/unittests/test_discovery.py
+++ b/tests/unittests/test_discovery.py
@@ -91,17 +91,24 @@ def _collect_bad_items(schema, path=""):
 class TestDiscoverReturnsCatalog(unittest.TestCase):
     """discover() must return a populated singer Catalog."""
 
+    def setUp(self):
+        self.client = _make_mock_client()
+        # Make all streams accessible so discover() completes without error
+        patcher = patch("tap_monday.discover._apply_access_checks")
+        self.mock_access = patcher.start()
+        self.addCleanup(patcher.stop)
+
     def test_returns_catalog_instance(self):
-        catalog = discover()
+        catalog = discover(self.client)
         self.assertIsInstance(catalog, Catalog)
 
     def test_catalog_has_all_streams(self):
-        catalog = discover()
+        catalog = discover(self.client)
         catalog_stream_names = {entry.stream for entry in catalog.streams}
         self.assertEqual(catalog_stream_names, set(STREAMS.keys()))
 
     def test_no_duplicate_streams(self):
-        catalog = discover()
+        catalog = discover(self.client)
         names = [entry.stream for entry in catalog.streams]
         self.assertEqual(len(names), len(set(names)),
                          "discover() produced duplicate catalog entries")
@@ -116,7 +123,9 @@ class TestCatalogEntryFields(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.catalog = discover()
+        client = _make_mock_client()
+        with patch("tap_monday.discover._apply_access_checks"):
+            cls.catalog = discover(client)
         cls.entries = {e.stream: e for e in cls.catalog.streams}
 
     def test_stream_equals_tap_stream_id(self):
@@ -169,7 +178,9 @@ class TestFieldInclusionMetadata(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.catalog = discover()
+        client = _make_mock_client()
+        with patch("tap_monday.discover._apply_access_checks"):
+            cls.catalog = discover(client)
 
     def test_all_fields_have_inclusion(self):
         from singer import metadata as md
@@ -191,7 +202,9 @@ class TestFieldInclusionMetadata(unittest.TestCase):
         for name, stream_cls in STREAMS.items():
             if not stream_cls.replication_keys:
                 continue
-            catalog = discover()
+            client = _make_mock_client()
+            with patch("tap_monday.discover._apply_access_checks"):
+                catalog = discover(client)
             entries = {e.stream: e for e in catalog.streams}
             entry = entries[name]
             mdata_map = md.to_map(entry.metadata)
@@ -341,12 +354,12 @@ class TestDiscoverErrorHandling(unittest.TestCase):
     @patch("tap_monday.discover.get_schemas", side_effect=FileNotFoundError("missing schema"))
     def test_propagates_file_not_found(self, _mock):
         with self.assertRaises(FileNotFoundError):
-            discover()
+            discover(_make_mock_client())
 
     @patch("tap_monday.discover.get_schemas", side_effect=json.JSONDecodeError("bad json", "", 0))
     def test_propagates_json_decode_error(self, _mock):
         with self.assertRaises(json.JSONDecodeError):
-            discover()
+            discover(_make_mock_client())
 
     @patch("tap_monday.discover.get_schemas")
     def test_propagates_schema_key_error(self, mock_get_schemas):
@@ -356,7 +369,7 @@ class TestDiscoverErrorHandling(unittest.TestCase):
             {"bad_stream": []}
         )
         with self.assertRaises(Exception):
-            discover()
+            discover(_make_mock_client())
 
 
 # ---------------------------------------------------------------------------
@@ -368,7 +381,9 @@ class TestSchemaPropertyConsistency(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.catalog = discover()
+        client = _make_mock_client()
+        with patch("tap_monday.discover._apply_access_checks"):
+            cls.catalog = discover(client)
         cls.entries = {e.stream: e for e in cls.catalog.streams}
         cls.raw_schemas = _load_all_schemas()
 
@@ -466,10 +481,9 @@ class TestApplyAccessChecks(unittest.TestCase):
             self.assertIs(args[0], client)
 
     def test_discover_without_client_skips_access_checks(self):
-        """discover() with no client must skip _apply_access_checks."""
-        with patch("tap_monday.discover._apply_access_checks") as mock_check:
+        """discover() always calls _apply_access_checks — client is required."""
+        with self.assertRaises(TypeError):
             discover()
-            mock_check.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -537,7 +551,7 @@ class TestBaseStreamCheckAccess(unittest.TestCase):
         """Instantiate a stream with a mock client that either succeeds or raises 403."""
         client = _make_mock_client()
         if forbidden:
-            client.make_request.side_effect = MondayForbiddenError("403 Forbidden")
+            client.probe_request.side_effect = MondayForbiddenError("403 Forbidden")
         stream_cls = STREAMS[stream_name]
         return stream_cls(client=client)
 
@@ -554,13 +568,13 @@ class TestBaseStreamCheckAccess(unittest.TestCase):
         # board_columns has parent="boards"
         child_stream = self._make_stream_instance("board_columns", forbidden=True)
         self.assertTrue(child_stream.check_access())
-        # Even though make_request would raise 403, it should never be called
-        child_stream.client.make_request.assert_not_called()
+        # Even though probe_request would raise 403, it should never be called
+        child_stream.client.probe_request.assert_not_called()
 
     def test_check_access_makes_request_for_parent(self):
         stream = self._make_stream_instance("audit_event_catalogue", forbidden=False)
         stream.check_access()
-        stream.client.make_request.assert_called_once()
+        stream.client.probe_request.assert_called_once()
 
     def test_check_access_logs_warning_on_forbidden(self):
         stream = self._make_stream_instance("account", forbidden=True)

--- a/tests/unittests/test_discovery.py
+++ b/tests/unittests/test_discovery.py
@@ -14,16 +14,20 @@ Covers:
   8.  get_schemas() returns entries for every STREAMS key.
   9.  discover() propagates exceptions raised by get_schemas().
   10. Schema properties match the corresponding CatalogEntry schema fields.
+  11. Access checks: inaccessible streams excluded from catalog.
+  12. Access checks: child streams removed when parent is excluded.
+  13. Access checks: MondayForbiddenError raised when all parent streams blocked.
 """
 
 import json
 import os
 import unittest
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from singer.catalog import Catalog
 
-from tap_monday.discover import discover
+from tap_monday.discover import discover, _apply_access_checks, _prune_inaccessible_children
+from tap_monday.exceptions import MondayForbiddenError
 from tap_monday.schema import get_schemas, get_abs_path
 from tap_monday.streams import STREAMS
 
@@ -378,3 +382,217 @@ class TestSchemaPropertyConsistency(unittest.TestCase):
                     actual_fields, expected_fields,
                     f"CatalogEntry schema properties for '{name}' differ from raw schema file"
                 )
+
+
+# ---------------------------------------------------------------------------
+# 11 – Access checks: inaccessible streams excluded from catalog
+# ---------------------------------------------------------------------------
+
+def _make_mock_client():
+    """Return a MagicMock that passes as a tap_monday Client."""
+    client = MagicMock()
+    client.config = {"start_date": "2024-01-01T00:00:00Z"}
+    return client
+
+
+class TestApplyAccessChecks(unittest.TestCase):
+    """_apply_access_checks() must mutate schemas/field_metadata in place."""
+
+    def _schemas_and_metadata(self):
+        return get_schemas()
+
+    def test_all_accessible_leaves_catalog_intact(self):
+        schemas, field_metadata = self._schemas_and_metadata()
+        original_keys = set(schemas.keys())
+        client = _make_mock_client()
+        with patch("tap_monday.discover.STREAMS", {
+            name: _make_accessible_stream_cls(name, cls)
+            for name, cls in STREAMS.items()
+        }):
+            _apply_access_checks(client, schemas, field_metadata)
+        self.assertEqual(set(schemas.keys()), original_keys)
+
+    def test_inaccessible_parent_excluded(self):
+        schemas, field_metadata = self._schemas_and_metadata()
+        client = _make_mock_client()
+        # Make 'audit_event_catalogue' forbidden, all others accessible
+        patched = {
+            name: _make_forbidden_stream_cls(name, cls) if name == "audit_event_catalogue"
+            else _make_accessible_stream_cls(name, cls)
+            for name, cls in STREAMS.items()
+        }
+        with patch("tap_monday.discover.STREAMS", patched):
+            _apply_access_checks(client, schemas, field_metadata)
+        self.assertNotIn("audit_event_catalogue", schemas)
+        self.assertNotIn("audit_event_catalogue", field_metadata)
+
+    def test_inaccessible_stream_warning_is_logged(self):
+        schemas, field_metadata = self._schemas_and_metadata()
+        client = _make_mock_client()
+        patched = {
+            name: _make_forbidden_stream_cls(name, cls) if name == "audit_event_catalogue"
+            else _make_accessible_stream_cls(name, cls)
+            for name, cls in STREAMS.items()
+        }
+        with patch("tap_monday.discover.STREAMS", patched):
+            with patch("tap_monday.discover.LOGGER") as mock_logger:
+                _apply_access_checks(client, schemas, field_metadata)
+                mock_logger.warning.assert_called()
+                warning_call_args = " ".join(
+                    str(a) for a in mock_logger.warning.call_args_list[-1][0]
+                )
+                self.assertIn("audit_event_catalogue", warning_call_args)
+
+    def test_all_parents_inaccessible_raises_forbidden_error(self):
+        schemas, field_metadata = self._schemas_and_metadata()
+        client = _make_mock_client()
+        # Make every parent stream forbidden
+        patched = {
+            name: _make_forbidden_stream_cls(name, cls) if not cls.parent
+            else _make_accessible_stream_cls(name, cls)
+            for name, cls in STREAMS.items()
+        }
+        with patch("tap_monday.discover.STREAMS", patched):
+            with self.assertRaises(MondayForbiddenError):
+                _apply_access_checks(client, schemas, field_metadata)
+
+    def test_discover_with_client_runs_access_checks(self):
+        """discover(client) must call _apply_access_checks."""
+        client = _make_mock_client()
+        with patch("tap_monday.discover._apply_access_checks") as mock_check:
+            discover(client)
+            mock_check.assert_called_once()
+            args = mock_check.call_args[0]
+            self.assertIs(args[0], client)
+
+    def test_discover_without_client_skips_access_checks(self):
+        """discover() with no client must skip _apply_access_checks."""
+        with patch("tap_monday.discover._apply_access_checks") as mock_check:
+            discover()
+            mock_check.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# 12 – Child streams removed when parent is excluded
+# ---------------------------------------------------------------------------
+
+class TestPruneInaccessibleChildren(unittest.TestCase):
+    """_prune_inaccessible_children() must remove orphaned child streams."""
+
+    def _schemas_and_metadata(self):
+        return get_schemas()
+
+    def test_children_of_excluded_parent_are_removed(self):
+        schemas, field_metadata = self._schemas_and_metadata()
+        # Simulate 'boards' being excluded — its children should be pruned
+        schemas.pop("boards", None)
+        field_metadata.pop("boards", None)
+        _prune_inaccessible_children(schemas, field_metadata)
+        board_children = [
+            name for name, cls in STREAMS.items()
+            if cls.parent == "boards"
+        ]
+        for child in board_children:
+            with self.subTest(child=child):
+                self.assertNotIn(child, schemas)
+                self.assertNotIn(child, field_metadata)
+
+    def test_grandchildren_excluded_when_parent_excluded(self):
+        """column_values is a child of board_items which is a child of boards."""
+        schemas, field_metadata = self._schemas_and_metadata()
+        # Remove boards — its child board_items gets pruned first
+        schemas.pop("boards", None)
+        field_metadata.pop("boards", None)
+        _prune_inaccessible_children(schemas, field_metadata)
+        # board_items is now gone; column_values (child of board_items) must also go
+        # Re-apply to simulate cascading
+        _prune_inaccessible_children(schemas, field_metadata)
+        self.assertNotIn("board_items", schemas)
+        self.assertNotIn("column_values", schemas)
+
+    def test_accessible_streams_unaffected_by_pruning(self):
+        schemas, field_metadata = self._schemas_and_metadata()
+        before = set(schemas.keys())
+        _prune_inaccessible_children(schemas, field_metadata)
+        # No parent was removed, so nothing should be pruned
+        self.assertEqual(set(schemas.keys()), before)
+
+    def test_child_warning_logged_when_pruned(self):
+        schemas, field_metadata = self._schemas_and_metadata()
+        schemas.pop("boards", None)
+        field_metadata.pop("boards", None)
+        with patch("tap_monday.discover.LOGGER") as mock_logger:
+            _prune_inaccessible_children(schemas, field_metadata)
+            mock_logger.warning.assert_called()
+
+
+# ---------------------------------------------------------------------------
+# 13 – BaseStream.check_access()
+# ---------------------------------------------------------------------------
+
+class TestBaseStreamCheckAccess(unittest.TestCase):
+    """BaseStream.check_access() must return True/False based on API response."""
+
+    def _make_stream_instance(self, stream_name, forbidden=False):
+        """Instantiate a stream with a mock client that either succeeds or raises 403."""
+        client = _make_mock_client()
+        if forbidden:
+            client.make_request.side_effect = MondayForbiddenError("403 Forbidden")
+        stream_cls = STREAMS[stream_name]
+        return stream_cls(client=client)
+
+    def test_accessible_stream_returns_true(self):
+        stream = self._make_stream_instance("account", forbidden=False)
+        self.assertTrue(stream.check_access())
+
+    def test_forbidden_stream_returns_false(self):
+        stream = self._make_stream_instance("account", forbidden=True)
+        self.assertFalse(stream.check_access())
+
+    def test_child_stream_always_returns_true(self):
+        """Child streams skip the HTTP probe and always return True."""
+        # board_columns has parent="boards"
+        child_stream = self._make_stream_instance("board_columns", forbidden=True)
+        self.assertTrue(child_stream.check_access())
+        # Even though make_request would raise 403, it should never be called
+        child_stream.client.make_request.assert_not_called()
+
+    def test_check_access_makes_request_for_parent(self):
+        stream = self._make_stream_instance("audit_event_catalogue", forbidden=False)
+        stream.check_access()
+        stream.client.make_request.assert_called_once()
+
+    def test_check_access_logs_warning_on_forbidden(self):
+        stream = self._make_stream_instance("account", forbidden=True)
+        with patch("tap_monday.streams.abstracts.LOGGER") as mock_logger:
+            result = stream.check_access()
+            self.assertFalse(result)
+            mock_logger.warning.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Helper factories used by access-check tests
+# ---------------------------------------------------------------------------
+
+def _make_accessible_stream_cls(name, original_cls):
+    """Return a subclass of the original that overrides check_access to return True."""
+    class _Accessible(original_cls):
+        def check_access(self):
+            return True
+    _Accessible.parent = original_cls.parent
+    _Accessible.children = original_cls.children
+    _Accessible.tap_stream_id = original_cls.tap_stream_id
+    _Accessible.__name__ = original_cls.__name__
+    return _Accessible
+
+
+def _make_forbidden_stream_cls(name, original_cls):
+    """Return a subclass of the original that overrides check_access to return False."""
+    class _Forbidden(original_cls):
+        def check_access(self):
+            return False
+    _Forbidden.parent = original_cls.parent
+    _Forbidden.children = original_cls.children
+    _Forbidden.tap_stream_id = original_cls.tap_stream_id
+    _Forbidden.__name__ = original_cls.__name__
+    return _Forbidden

--- a/tests/unittests/test_discovery.py
+++ b/tests/unittests/test_discovery.py
@@ -27,7 +27,7 @@ from unittest.mock import MagicMock, patch
 from singer.catalog import Catalog
 
 from tap_monday.discover import discover, _apply_access_checks, _prune_inaccessible_children
-from tap_monday.exceptions import MondayForbiddenError, MondayInternalServerError
+from tap_monday.exceptions import MondayForbiddenError, MondayGraphQLInternalError
 from tap_monday.schema import get_schemas, get_abs_path
 from tap_monday.streams import STREAMS
 
@@ -471,15 +471,15 @@ class TestApplyAccessChecks(unittest.TestCase):
             with self.assertRaises(MondayForbiddenError):
                 _apply_access_checks(client, schemas, field_metadata)
 
-    def test_all_parents_inaccessible_via_500_raises_internal_server_error(self):
-        """When all failures are 500s (not 403s), MondayInternalServerError must be raised."""
+    def test_all_parents_inaccessible_via_graphql_error_raises(self):
+        """When all streams are inaccessible (any error type), MondayForbiddenError must be raised."""
         schemas, field_metadata = self._schemas_and_metadata()
         client = _make_mock_client()
 
         def _make_500_stream_cls(name, original_cls):
             class _ServerError(original_cls):
                 def check_access(self):
-                    return MondayInternalServerError("500")
+                    return False
             _ServerError.parent = original_cls.parent
             _ServerError.children = original_cls.children
             _ServerError.tap_stream_id = original_cls.tap_stream_id
@@ -492,7 +492,7 @@ class TestApplyAccessChecks(unittest.TestCase):
             for name, cls in STREAMS.items()
         }
         with patch("tap_monday.discover.STREAMS", patched):
-            with self.assertRaises(MondayInternalServerError):
+            with self.assertRaises(MondayForbiddenError):
                 _apply_access_checks(client, schemas, field_metadata)
 
     def test_discover_with_client_runs_access_checks(self):
@@ -503,12 +503,6 @@ class TestApplyAccessChecks(unittest.TestCase):
             mock_check.assert_called_once()
             args = mock_check.call_args[0]
             self.assertIs(args[0], client)
-
-    def test_discover_without_client_skips_access_checks(self):
-        """discover() always calls _apply_access_checks — client is required."""
-        with self.assertRaises(TypeError):
-            discover()
-
 
 # ---------------------------------------------------------------------------
 # 12 – Child streams removed when parent is excluded
@@ -569,7 +563,7 @@ class TestPruneInaccessibleChildren(unittest.TestCase):
 # ---------------------------------------------------------------------------
 
 class TestBaseStreamCheckAccess(unittest.TestCase):
-    """BaseStream.check_access() must return None or an exception based on API response."""
+    """BaseStream.check_access() must return True (accessible) or False (inaccessible)."""
 
     def _make_stream_instance(self, stream_name, forbidden=False):
         """Instantiate a stream with a mock client that either succeeds or raises 403."""
@@ -579,24 +573,24 @@ class TestBaseStreamCheckAccess(unittest.TestCase):
         stream_cls = STREAMS[stream_name]
         return stream_cls(client=client)
 
-    def test_accessible_stream_returns_none(self):
+    def test_accessible_stream_returns_true(self):
         stream = self._make_stream_instance("account", forbidden=False)
-        self.assertIsNone(stream.check_access())
+        self.assertTrue(stream.check_access())
 
-    def test_forbidden_stream_returns_exception(self):
+    def test_forbidden_stream_returns_false(self):
         stream = self._make_stream_instance("account", forbidden=True)
-        self.assertIsInstance(stream.check_access(), MondayForbiddenError)
+        self.assertFalse(stream.check_access())
 
-    def test_internal_server_error_stream_returns_exception(self):
+    def test_graphql_internal_error_returns_false(self):
         stream = self._make_stream_instance("account")
-        stream.client.probe_request.side_effect = MondayInternalServerError("500")
-        self.assertIsInstance(stream.check_access(), MondayInternalServerError)
+        stream.client.probe_request.side_effect = MondayGraphQLInternalError("INTERNAL_SERVER_ERROR")
+        self.assertFalse(stream.check_access())
 
-    def test_child_stream_always_returns_none(self):
-        """Child streams skip the HTTP probe and always return None."""
+    def test_child_stream_always_returns_true(self):
+        """Child streams skip the HTTP probe and always return True."""
         # board_columns has parent="boards"
         child_stream = self._make_stream_instance("board_columns", forbidden=True)
-        self.assertIsNone(child_stream.check_access())
+        self.assertTrue(child_stream.check_access())
         # Even though probe_request would raise 403, it should never be called
         child_stream.client.probe_request.assert_not_called()
 
@@ -609,7 +603,7 @@ class TestBaseStreamCheckAccess(unittest.TestCase):
         stream = self._make_stream_instance("account", forbidden=True)
         with patch("tap_monday.streams.abstracts.LOGGER") as mock_logger:
             result = stream.check_access()
-            self.assertIsInstance(result, MondayForbiddenError)
+            self.assertFalse(result)
             mock_logger.warning.assert_called_once()
 
 
@@ -618,10 +612,10 @@ class TestBaseStreamCheckAccess(unittest.TestCase):
 # ---------------------------------------------------------------------------
 
 def _make_accessible_stream_cls(name, original_cls):
-    """Return a subclass of the original that overrides check_access to return None (accessible)."""
+    """Return a subclass of the original that overrides check_access to return True (accessible)."""
     class _Accessible(original_cls):
         def check_access(self):
-            return None
+            return True
     _Accessible.parent = original_cls.parent
     _Accessible.children = original_cls.children
     _Accessible.tap_stream_id = original_cls.tap_stream_id
@@ -630,10 +624,10 @@ def _make_accessible_stream_cls(name, original_cls):
 
 
 def _make_forbidden_stream_cls(name, original_cls):
-    """Return a subclass of the original that overrides check_access to return a MondayForbiddenError."""
+    """Return a subclass of the original that overrides check_access to return False (inaccessible)."""
     class _Forbidden(original_cls):
         def check_access(self):
-            return MondayForbiddenError("403 Forbidden")
+            return False
     _Forbidden.parent = original_cls.parent
     _Forbidden.children = original_cls.children
     _Forbidden.tap_stream_id = original_cls.tap_stream_id


### PR DESCRIPTION
# Description of change
This PR updates 
- Stream discovery behavior for inaccessible resources.
- Streams that the provided credentials cannot access are now excluded from the catalog instead of causing discovery to fail.
- Child streams are automatically pruned when their parent stream is inaccessible.
- If no streams are accessible with the provided credentials, a MondayForbiddenError is raised.
- PR also adds field-level plan gating for the `platform_api` stream's daily_limit field.

**Manual QA steps**
- [x] Discovery: Running
- [x] Sync: Running
- [x] Unit tests: Running
- [x] Integration Tests: Running
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
